### PR TITLE
Download filename

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -316,7 +316,8 @@
     </target>
 
 
-
+    <!-- It would be better if this target only copied the files that have chenaged.
+         jhrg 5/26/16 -->
     <target name="check"
             description="Run Unit Tests"
             depends="compile"
@@ -332,6 +333,8 @@
 
           <test name="opendap.coreServlet.Scrub" />
           <test name="opendap.aggregation.AggregationParamsTest" />
+
+          <test name="opendap.bes.dap4Responders.Dap4ResponderTest" />
 
         </junit>
     </target>

--- a/src/opendap/bes/BesDapDispatcher.java
+++ b/src/opendap/bes/BesDapDispatcher.java
@@ -72,6 +72,7 @@ public class BesDapDispatcher implements DispatchHandler {
     private Vector<Dap4Responder> _responders;
     private static boolean _allowDirectDataSourceAccess = false;
     private static boolean _useDAP2ResourceUrlResponse = false;
+    private static boolean _addFileoutTypeSuffixToDownloadFilename = false;
 
 
     private BesApi _besApi;
@@ -147,12 +148,14 @@ public class BesDapDispatcher implements DispatchHandler {
 
             }
 
+            _log.info("ingestConfig() - Using BES API implementation: "+getBesApi().getClass().getName());
 
             _allowDirectDataSourceAccess = false;
             Element dv = _config.getChild("AllowDirectDataSourceAccess");
             if (dv != null) {
                 _allowDirectDataSourceAccess = true;
             }
+            _log.info("ingestConfig() - AllowDirectDataSourceAccess: {}",_allowDirectDataSourceAccess);
 
 
             _useDAP2ResourceUrlResponse = false;
@@ -160,6 +163,14 @@ public class BesDapDispatcher implements DispatchHandler {
             if (dv != null) {
                 _useDAP2ResourceUrlResponse = true;
             }
+            _log.info("ingestConfig() - UseDAP2ResourceUrlResponse: {}",_useDAP2ResourceUrlResponse);
+
+            _addFileoutTypeSuffixToDownloadFilename = false;
+            dv = _config.getChild("AddFileoutTypeSuffixToDownloadFilename");
+            if (dv != null) {
+                _addFileoutTypeSuffixToDownloadFilename = true;
+            }
+            _log.info("ingestConfig() - AddFileoutTypeSuffixToDownloadFilename: {}",_addFileoutTypeSuffixToDownloadFilename);
 
 
             dv = _config.getChild("PostBodyMaxLength");
@@ -173,7 +184,7 @@ public class BesDapDispatcher implements DispatchHandler {
 
                 }
             }
-            _log.info("PostBodyMaxLength is set to {}", ReqInfo.getPostBodyMaxLength());
+            _log.info("ingestConfig() - PostBodyMaxLength is set to {}", ReqInfo.getPostBodyMaxLength());
 
         }
 
@@ -211,8 +222,8 @@ public class BesDapDispatcher implements DispatchHandler {
         NormativeDSR ndsr = new NormativeDSR(_systemPath, null, ".dsr", besApi,_responders);
         _responders.add(ndsr);
 
-        _responders.add(new NormativeDR(_systemPath, besApi));
-        _responders.add(new NormativeDMR(_systemPath, besApi));
+        _responders.add(new NormativeDR(_systemPath, besApi, _addFileoutTypeSuffixToDownloadFilename));
+        _responders.add(new NormativeDMR(_systemPath, besApi, _addFileoutTypeSuffixToDownloadFilename));
         _responders.add(new IsoDMR(_systemPath, besApi));
 
         _responders.add(new Version(_systemPath, besApi));
@@ -227,30 +238,30 @@ public class BesDapDispatcher implements DispatchHandler {
 
 
         // DAP2 Data Responses
-        _responders.add(new Dap2Data(_systemPath, besApi));
+        _responders.add(new Dap2Data(_systemPath, besApi, _addFileoutTypeSuffixToDownloadFilename));
         _responders.add(   new Ascii(_systemPath, besApi));
         //responders.add(new Ascii(systemPath, null, ".asc", besApi)); // We can uncomment this if we want to support both the dap2 ".ascii" suffix and ".asc"
         _responders.add( new CsvData(_systemPath, besApi));
-        _responders.add( new Netcdf3(_systemPath, besApi));
-        _responders.add( new Netcdf4(_systemPath, besApi));
-        _responders.add( new XmlData(_systemPath, besApi));
+        _responders.add( new Netcdf3(_systemPath, besApi, _addFileoutTypeSuffixToDownloadFilename));
+        _responders.add( new Netcdf4(_systemPath, besApi, _addFileoutTypeSuffixToDownloadFilename));
+        _responders.add( new XmlData(_systemPath, besApi, _addFileoutTypeSuffixToDownloadFilename));
 
 
         // DAP2 GeoTIFF Response
-        Dap4Responder geoTiff = new GeoTiff(_systemPath, besApi);
+        Dap4Responder geoTiff = new GeoTiff(_systemPath, besApi, _addFileoutTypeSuffixToDownloadFilename);
         _responders.add(geoTiff);
 
 
         // DAP2 JPEG2000 Response
-        Dap4Responder jp2 = new GmlJpeg2000(_systemPath, besApi);
+        Dap4Responder jp2 = new GmlJpeg2000(_systemPath, besApi, _addFileoutTypeSuffixToDownloadFilename);
         _responders.add(jp2);
 
         // DAP2 w10n JSON Response
-        Dap4Responder json = new Json(_systemPath, besApi);
+        Dap4Responder json = new Json(_systemPath, besApi, _addFileoutTypeSuffixToDownloadFilename);
         _responders.add(json);
 
         // DAP2 Instance Object JSON Response
-        Dap4Responder ijsn = new Ijson(_systemPath, besApi);
+        Dap4Responder ijsn = new Ijson(_systemPath, besApi, _addFileoutTypeSuffixToDownloadFilename);
         _responders.add(ijsn);
 
 
@@ -259,7 +270,7 @@ public class BesDapDispatcher implements DispatchHandler {
         _responders.add(d4r);
         _responders.add(new DDS(_systemPath, besApi));
         _responders.add(new DAS(_systemPath, besApi));
-        _responders.add(new RDF(_systemPath, besApi));
+        _responders.add(new RDF(_systemPath, besApi, _addFileoutTypeSuffixToDownloadFilename));
         _responders.add(new DatasetInfoHtmlPage(_systemPath, besApi));
 
         Dap4Responder iso = new Iso19115(_systemPath, besApi);

--- a/src/opendap/bes/dap2Responders/Dap2Data.java
+++ b/src/opendap/bes/dap2Responders/Dap2Data.java
@@ -60,19 +60,17 @@ public class Dap2Data extends Dap4Responder {
     private static String _defaultRequestSuffix = ".dods";
 
 
-    public Dap2Data(String sysPath, BesApi besApi) {
-        this(sysPath,null, _defaultRequestSuffix,besApi);
-    }
-
-    public Dap2Data(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath,pathPrefix, _defaultRequestSuffix,besApi);
+    public Dap2Data(String sysPath, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath,null, _defaultRequestSuffix,besApi,addTypeSuffixToDownloadFilename);
     }
 
 
-    public Dap2Data(String sysPath, String pathPrefix,  String requestSuffixRegex, BesApi besApi) {
+
+    public Dap2Data(String sysPath, String pathPrefix,  String requestSuffixRegex, BesApi besApi,boolean addTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
+        addTypeSuffixToDownloadFilename(addTypeSuffixToDownloadFilename);
         setServiceRoleId("http://services.opendap.org/dap2/data");
         setServiceTitle("DAP2 Data");
         setServiceDescription("DAP2 Data Object.");

--- a/src/opendap/bes/dap2Responders/GeoTiff.java
+++ b/src/opendap/bes/dap2Responders/GeoTiff.java
@@ -48,17 +48,15 @@ public class GeoTiff extends Dap4Responder {
     private Logger log;
     private static String defaultRequestSuffix = ".tiff";
 
-    public GeoTiff(String sysPath, BesApi besApi) {
-        this(sysPath, null, defaultRequestSuffix, besApi);
+    public GeoTiff(String sysPath, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, null, defaultRequestSuffix, besApi,addTypeSuffixToDownloadFilename);
     }
 
-    public GeoTiff(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath, pathPrefix, defaultRequestSuffix, besApi);
-    }
 
-    public GeoTiff(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi) {
+    public GeoTiff(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
+        addTypeSuffixToDownloadFilename(addTypeSuffixToDownloadFilename);
 
         setServiceRoleId("http://services.opendap.org/dap4/data/geotiff");
         setServiceTitle("GeoTIFF Data Response");

--- a/src/opendap/bes/dap2Responders/GmlJpeg2000.java
+++ b/src/opendap/bes/dap2Responders/GmlJpeg2000.java
@@ -49,18 +49,15 @@ public class GmlJpeg2000 extends Dap4Responder {
     private Logger log;
     private static String defaultRequestSuffix = ".jp2";
 
-    public GmlJpeg2000(String sysPath, BesApi besApi) {
-        this(sysPath, null, defaultRequestSuffix, besApi);
+    public GmlJpeg2000(String sysPath, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, null, defaultRequestSuffix, besApi, addTypeSuffixToDownloadFilename);
     }
 
-    public GmlJpeg2000(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath, pathPrefix, defaultRequestSuffix, besApi);
-    }
-
-    public GmlJpeg2000(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi) {
+    public GmlJpeg2000(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
+        addTypeSuffixToDownloadFilename(addTypeSuffixToDownloadFilename);
         setServiceRoleId("http://services.opendap.org/dap4/data/gmljp2");
         setServiceTitle("GML-JPEG2000 Data Response");
         setServiceDescription("GML-JPEG2000 representation of the DAP4 Data Response object.");

--- a/src/opendap/bes/dap2Responders/Ijson.java
+++ b/src/opendap/bes/dap2Responders/Ijson.java
@@ -48,18 +48,16 @@ public class Ijson extends Dap4Responder {
     private Logger log;
     private static String defaultRequestSuffix = ".ijsn";
 
-    public Ijson(String sysPath, BesApi besApi) {
-        this(sysPath, null, defaultRequestSuffix, besApi);
+    public Ijson(String sysPath, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, null, defaultRequestSuffix, besApi, addTypeSuffixToDownloadFilename);
     }
 
-    public Ijson(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath, pathPrefix, defaultRequestSuffix, besApi);
-    }
 
-    public Ijson(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi) {
+    public Ijson(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
+        addTypeSuffixToDownloadFilename(addTypeSuffixToDownloadFilename);
         setServiceRoleId("http://services.opendap.org/dap2/data/json");
         setServiceTitle("JSON encoded DAP2 data.");
         setServiceDescription("JSON representation of the DAP2 Data Response object.");

--- a/src/opendap/bes/dap2Responders/Json.java
+++ b/src/opendap/bes/dap2Responders/Json.java
@@ -48,18 +48,15 @@ public class Json extends Dap4Responder {
     private Logger log;
     private static String defaultRequestSuffix = ".json";
 
-    public Json(String sysPath, BesApi besApi) {
-        this(sysPath, null, defaultRequestSuffix, besApi);
+    public Json(String sysPath, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, null, defaultRequestSuffix, besApi, addTypeSuffixToDownloadFilename);
     }
 
-    public Json(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath, pathPrefix, defaultRequestSuffix, besApi);
-    }
-
-    public Json(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi) {
+    public Json(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
+        addTypeSuffixToDownloadFilename(addTypeSuffixToDownloadFilename);
         setServiceRoleId("http://services.opendap.org/dap2/data/json");
         setServiceTitle("JSON encoded DAP2 data.");
         setServiceDescription("JSON representation of the DAP2 Data Response object.");

--- a/src/opendap/bes/dap2Responders/Netcdf3.java
+++ b/src/opendap/bes/dap2Responders/Netcdf3.java
@@ -54,19 +54,16 @@ public class Netcdf3 extends Dap4Responder {
     private static String defaultRequestSuffix = ".nc";
 
 
-
-    public Netcdf3(String sysPath, BesApi besApi) {
-        this(sysPath, null, defaultRequestSuffix, besApi);
+    public Netcdf3(String sysPath, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, null, defaultRequestSuffix, besApi, addTypeSuffixToDownloadFilename);
     }
 
-    public Netcdf3(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath, pathPrefix, defaultRequestSuffix, besApi);
-    }
 
-    public Netcdf3(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi) {
+    public Netcdf3(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
+        addTypeSuffixToDownloadFilename(addTypeSuffixToDownloadFilename);
         setServiceRoleId("http://services.opendap.org/dap4/data/netcdf-3");
         setServiceTitle("NetCDF-3 Data Response");
         setServiceDescription("NetCDF-3 representation of the DAP2 Data Response object.");
@@ -84,6 +81,16 @@ public class Netcdf3 extends Dap4Responder {
     public boolean isMetadataResponder(){ return false; }
 
 
+    @Override
+    public String getDownloadFileName(String resourceID){
+
+        String downloadFileName = super.getDownloadFileName(resourceID);
+        Pattern startsWithNumber = Pattern.compile("[0-9].*");
+        if(startsWithNumber.matcher(downloadFileName).matches())
+            downloadFileName = "nc_"+downloadFileName;
+
+        return downloadFileName;
+    }
 
 
 

--- a/src/opendap/bes/dap2Responders/Netcdf3.java
+++ b/src/opendap/bes/dap2Responders/Netcdf3.java
@@ -81,6 +81,13 @@ public class Netcdf3 extends Dap4Responder {
     public boolean isMetadataResponder(){ return false; }
 
 
+    /**
+     * For netCDF3, examine the name and prefix it with 'nc_' if the 
+     * name would otherwise not be an acceptable filename (in 
+     * practice this means 'if the name starts with a number').
+     * 
+     * {@inheritDoc}
+     */
     @Override
     public String getDownloadFileName(String resourceID){
 

--- a/src/opendap/bes/dap2Responders/Netcdf4.java
+++ b/src/opendap/bes/dap2Responders/Netcdf4.java
@@ -55,18 +55,17 @@ public class Netcdf4 extends Dap4Responder {
 
 
 
-    public Netcdf4(String sysPath, BesApi besApi) {
-        this(sysPath, null, defaultRequestSuffix, besApi);
+    public Netcdf4(String sysPath, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
+
+        this(sysPath, null, defaultRequestSuffix, besApi,addFileoutTypeSuffixToDownloadFilename);
     }
 
-    public Netcdf4(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath, pathPrefix, defaultRequestSuffix, besApi);
-    }
 
-    public Netcdf4(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi) {
+    public Netcdf4(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
+        addTypeSuffixToDownloadFilename(addFileoutTypeSuffixToDownloadFilename);
         setServiceRoleId("http://services.opendap.org/dap4/data/netcdf-4");
         setServiceTitle("NetCDF-4 Data Response");
         setServiceDescription("NetCDF-4 representation of the DAP2 Data Response object.");
@@ -84,6 +83,16 @@ public class Netcdf4 extends Dap4Responder {
     public boolean isMetadataResponder(){ return false; }
 
 
+    @Override
+    public String getDownloadFileName(String resourceID){
+
+        String downloadFileName = super.getDownloadFileName(resourceID);
+        Pattern startsWithNumber = Pattern.compile("[0-9].*");
+        if(startsWithNumber.matcher(downloadFileName).matches())
+            downloadFileName = "nc_"+downloadFileName;
+
+        return downloadFileName;
+    }
 
 
 
@@ -109,16 +118,8 @@ public class Netcdf4 extends Dap4Responder {
         response.setHeader("Content-Description", getNormativeMediaType().getMimeType());
 
         String downloadFileName = getDownloadFileName(resourceID);
-        Pattern startsWithNumber = Pattern.compile("[0-9].*");
-        if(startsWithNumber.matcher(downloadFileName).matches())
-            downloadFileName = "nc_"+downloadFileName;
-
-        downloadFileName = downloadFileName+".nc4";
-
         log.debug("respondToHttpGetRequest(): NetCDF file downloadFileName: " + downloadFileName );
-
         String contentDisposition = " attachment; filename=\"" +downloadFileName+"\"";
-
         response.setHeader("Content-Disposition", contentDisposition);
 
 

--- a/src/opendap/bes/dap2Responders/RDF.java
+++ b/src/opendap/bes/dap2Responders/RDF.java
@@ -53,16 +53,12 @@ public class RDF extends Dap4Responder {
 
     private static String _defaultRequestSuffix = ".rdf";
 
-    public RDF(String sysPath, BesApi besApi) {
-        this(sysPath,null, _defaultRequestSuffix,besApi);
-    }
-
-    public RDF(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath,pathPrefix, _defaultRequestSuffix,besApi);
+    public RDF(String sysPath, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath,null, _defaultRequestSuffix,besApi, addTypeSuffixToDownloadFilename);
     }
 
 
-    public RDF(String sysPath, String pathPrefix,  String requestSuffixRegex, BesApi besApi) {
+    public RDF(String sysPath, String pathPrefix,  String requestSuffixRegex, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
         setServiceRoleId("http://services.opendap.org/dap4/rdf");
@@ -116,6 +112,8 @@ public class RDF extends Dap4Responder {
 
         Version.setOpendapMimeHeaders(request,response,besApi);
         response.setHeader("Content-Description", "RDF Encoding of DAP2 DDX");
+
+        // response.setHeader("Content-Disposition", " attachment; filename=\"" +getDownloadFileName(resourceID)+"\"");
 
 
         String xdap_accept = "3.2";

--- a/src/opendap/bes/dap2Responders/XmlData.java
+++ b/src/opendap/bes/dap2Responders/XmlData.java
@@ -54,20 +54,18 @@ public class XmlData extends Dap4Responder {
     private static String _defaultRequestSuffix = ".xdap";
 
 
-    public XmlData(String sysPath, BesApi besApi) {
-        this(sysPath,null, _defaultRequestSuffix,besApi);
-    }
-
-    public XmlData(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath,pathPrefix, _defaultRequestSuffix,besApi);
+    public XmlData(String sysPath, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath,null, _defaultRequestSuffix,besApi, addTypeSuffixToDownloadFilename);
     }
 
 
 
-    public XmlData(String sysPath, String pathPrefix,  String requestSuffixRegex, BesApi besApi) {
+
+    public XmlData(String sysPath, String pathPrefix,  String requestSuffixRegex, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
+        addTypeSuffixToDownloadFilename(addTypeSuffixToDownloadFilename);
         setServiceRoleId("http://services.opendap.org/dap2/xml-data");
         setServiceTitle("DAP2 XML Data Response");
         setServiceDescription("An XML document containing both the DAP2 dataset's structural metadata along with data values.");
@@ -113,6 +111,7 @@ public class XmlData extends Dap4Responder {
         response.setHeader("Content-Description", "dap_xml");
         // Commented because of a bug in the OPeNDAP C++ stuff...
         //response.setHeader("Content-Encoding", "plain");
+        response.setHeader("Content-Disposition", " attachment; filename=\"" +getDownloadFileName(resourceID)+"\"");
 
         response.setStatus(HttpServletResponse.SC_OK);
         String xdap_accept = request.getHeader("XDAP-Accept");

--- a/src/opendap/bes/dap4Responders/Dap4Responder.java
+++ b/src/opendap/bes/dap4Responders/Dap4Responder.java
@@ -532,10 +532,10 @@ public abstract class Dap4Responder extends BesDapResponder  {
         // a reasonable compromise).
         
         if(addTypeSuffixToDownloadFilename()) {
-        	int dotPos = name.lastIndexOf(".");
+        	int dotPos = name.lastIndexOf('.');	// -1 if '.' not found
         	int extLength = name.length() - (dotPos + 1);
 
-        	if (extLength > 0 && extLength < 4) {
+        	if (dotPos != -1 && (extLength > 0 && extLength < 4)) {
         		name = name.substring(0, dotPos);
         	}
         }

--- a/src/opendap/bes/dap4Responders/Dap4Responder.java
+++ b/src/opendap/bes/dap4Responders/Dap4Responder.java
@@ -512,15 +512,37 @@ public abstract class Dap4Responder extends BesDapResponder  {
     }
 
 
+    /**
+     * If addTypeSuffixToDownloadFilename() is true, append the value of
+     * getRequestSuffix() to the name.
+     * 
+     * {@inheritDoc}
+     */
     @Override
     public String getDownloadFileName(String resourceID){
         String name = super.getDownloadFileName(resourceID);
 
-        if(addTypeSuffixToDownloadFilename())
-            name += getRequestSuffix();
+        // old rule: add the suffix - there was no option
+        // old-new rule: if addTypeSuffixToDownloadFilename() is true, append getRequestSuffix().
+        // new rule: if addType...() is true, then look at 'name' and do one of the following:
+        //              file.<ext>: remove '.<ext>' and append the value of getRequestSuffix()
+        //              file [no ext at all]: append getRequestSuffix()
+        //           else if addType...() is not true, provide the old behavior 
+        // Assume that all <ext> are no more than three characters long (some are, but this is
+        // a reasonable compromise).
+        
+        if(addTypeSuffixToDownloadFilename()) {
+        	int dotPos = name.lastIndexOf(".");
+        	int extLength = name.length() - (dotPos + 1);
+
+        	if (extLength > 0 && extLength < 4) {
+        		name = name.substring(0, dotPos);
+        	}
+        }
+        	
+        name += getRequestSuffix();
 
         return name;
-
     }
 
 

--- a/src/opendap/bes/dap4Responders/Dap4Responder.java
+++ b/src/opendap/bes/dap4Responders/Dap4Responder.java
@@ -58,15 +58,25 @@ public abstract class Dap4Responder extends BesDapResponder  {
     private MediaType _normativeMediaType;
     private Vector<Dap4Responder> _altResponders;
     private String _combinedRequestSuffixRegex;
+    private boolean _addTypeSuffixToDownloadFilename;
 
 
 
     public Dap4Responder(String sysPath, String pathPrefix, String requestSuffix, BesApi besApi) {
         super(sysPath, pathPrefix, requestSuffix, besApi);
         _log = LoggerFactory.getLogger(getClass().getName());
-        _altResponders =  new Vector<Dap4Responder>();
+        _altResponders =  new Vector<>();
+        addTypeSuffixToDownloadFilename(false);
     }
 
+    public void addTypeSuffixToDownloadFilename(boolean value){
+        _addTypeSuffixToDownloadFilename = value;
+    }
+
+
+    public boolean addTypeSuffixToDownloadFilename(){
+        return _addTypeSuffixToDownloadFilename;
+    }
 
 
     public void setNormativeMediaType(MediaType mt){
@@ -499,6 +509,18 @@ public abstract class Dap4Responder extends BesDapResponder  {
                 description.setText(descriptionText);
         }
         return description;
+    }
+
+
+    @Override
+    public String getDownloadFileName(String resourceID){
+        String name = super.getDownloadFileName(resourceID);
+
+        if(addTypeSuffixToDownloadFilename())
+            name += getRequestSuffix();
+
+        return name;
+
     }
 
 

--- a/src/opendap/bes/dap4Responders/Dap4ResponderTest.java
+++ b/src/opendap/bes/dap4Responders/Dap4ResponderTest.java
@@ -106,10 +106,16 @@ public class Dap4ResponderTest {
         Assert.assertEquals(old_rule.getDownloadFileName("file.nc"), "file.nc.nc");
         Assert.assertEquals(old_rule.getDownloadFileName("file.hdf"), "file.hdf.nc");
         Assert.assertEquals(old_rule.getDownloadFileName("file.html"), "file.html.nc");
-        
+    	Assert.assertEquals(old_rule.getDownloadFileName("fi"), "fi.nc");
+    	Assert.assertEquals(old_rule.getDownloadFileName("fi.h5"), "fi.h5.nc");
+
         Assert.assertEquals(new_rule.getDownloadFileName("file"), "file.nc");
         Assert.assertEquals(new_rule.getDownloadFileName("file.nc"), "file.nc");
         Assert.assertEquals(new_rule.getDownloadFileName("file.hdf"), "file.nc");
         Assert.assertEquals(new_rule.getDownloadFileName("file.html"), "file.html.nc");
+        
+    	Assert.assertEquals(new_rule.getDownloadFileName("fi"), "fi.nc");
+    	Assert.assertEquals(new_rule.getDownloadFileName("fi.h5"), "fi.nc");
+
     }
 }

--- a/src/opendap/bes/dap4Responders/Dap4ResponderTest.java
+++ b/src/opendap/bes/dap4Responders/Dap4ResponderTest.java
@@ -1,0 +1,115 @@
+/*
+ * /////////////////////////////////////////////////////////////////////////////
+ * // This file is part of the "Hyrax Data Server" project.
+ * //
+ * //
+ * // Copyright (c) 2016 OPeNDAP, Inc.
+ * // Author: James Gallagher <jgallagher@opendap.org>
+ * //
+ * // This library is free software; you can redistribute it and/or
+ * // modify it under the terms of the GNU Lesser General Public
+ * // License as published by the Free Software Foundation; either
+ * // version 2.1 of the License, or (at your option) any later version.
+ * //
+ * // This library is distributed in the hope that it will be useful,
+ * // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * // Lesser General Public License for more details.
+ * //
+ * // You should have received a copy of the GNU Lesser General Public
+ * // License along with this library; if not, write to the Free Software
+ * // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+ * //
+ * // You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+ * /////////////////////////////////////////////////////////////////////////////
+ */
+
+package opendap.bes.dap4Responders;
+
+// This uses JUnit 4
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import opendap.bes.dap2Responders.BesApi;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @brief Test Dap4Responder.
+ * This currently only tests getDownloadFileName() which now (5/26/16)
+ * has a new behavior that it can selectively replace an existing extension
+ * or use the old behavior and always apply an extension.
+ * 
+ * Run the test using "ant check"
+ * 
+ * @author jimg
+ */
+public class Dap4ResponderTest {
+
+	private BesApi besApi;
+	private Dap4Responder old_rule, new_rule;
+	
+    @Before
+    // Dap4responder is abstract; I added stubs for the unimplemented methods
+    // so I can test the code I hacked in getDownloadFileName(). jhrg 5/26/16
+    public void setUp() throws Exception {
+    	old_rule = new Dap4Responder("", "", ".nc", besApi) {
+
+			@Override
+			public void sendNormativeRepresentation(HttpServletRequest request, HttpServletResponse response)
+					throws Exception {
+			}
+
+			@Override
+			public boolean isMetadataResponder() {
+				return false;
+			}
+
+			@Override
+			public boolean isDataResponder() {
+				return false;
+			}
+        };
+        
+        new_rule = new Dap4Responder("", "", ".nc", besApi) {
+
+			@Override
+			public void sendNormativeRepresentation(HttpServletRequest request, HttpServletResponse response)
+					throws Exception {
+			}
+
+			@Override
+			public boolean isMetadataResponder() {
+				return false;
+			}
+
+			@Override
+			public boolean isDataResponder() {
+				return false;
+			}
+        };
+        
+        new_rule.addTypeSuffixToDownloadFilename(true);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+    }
+
+    @Test
+    public void testGetDownloadFileName() throws Exception {
+        Assert.assertEquals(old_rule.getDownloadFileName("file"), "file.nc");
+        Assert.assertEquals(old_rule.getDownloadFileName("file.nc"), "file.nc.nc");
+        Assert.assertEquals(old_rule.getDownloadFileName("file.hdf"), "file.hdf.nc");
+        Assert.assertEquals(old_rule.getDownloadFileName("file.html"), "file.html.nc");
+        
+        Assert.assertEquals(new_rule.getDownloadFileName("file"), "file.nc");
+        Assert.assertEquals(new_rule.getDownloadFileName("file.nc"), "file.nc");
+        Assert.assertEquals(new_rule.getDownloadFileName("file.hdf"), "file.nc");
+        Assert.assertEquals(new_rule.getDownloadFileName("file.html"), "file.html.nc");
+    }
+}

--- a/src/opendap/bes/dap4Responders/DataResponse/CsvDR.java
+++ b/src/opendap/bes/dap4Responders/DataResponse/CsvDR.java
@@ -57,15 +57,15 @@ public class CsvDR extends Dap4Responder {
 
 
 
-    public CsvDR(String sysPath, BesApi besApi) {
-        this(sysPath, null, defaultRequestSuffix, besApi);
+    public CsvDR(String sysPath, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
+        this(sysPath, null, defaultRequestSuffix, besApi, addFileoutTypeSuffixToDownloadFilename);
     }
 
-    public CsvDR(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath, pathPrefix, defaultRequestSuffix, besApi);
+    public CsvDR(String sysPath, String pathPrefix, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
+        this(sysPath, pathPrefix, defaultRequestSuffix, besApi, addFileoutTypeSuffixToDownloadFilename);
     }
 
-    public CsvDR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi) {
+    public CsvDR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
@@ -110,6 +110,8 @@ public class CsvDR extends Dap4Responder {
         response.setContentType(responseMediaType.getMimeType());
         Version.setOpendapMimeHeaders(request, response, besApi);
         response.setHeader("Content-Description", getNormativeMediaType().getMimeType());
+
+        response.setHeader("Content-Disposition", " attachment; filename=\"" +getDownloadFileName(resourceID)+"\"");
 
 
         User user = new User(request);

--- a/src/opendap/bes/dap4Responders/DataResponse/GeoTiffDR.java
+++ b/src/opendap/bes/dap4Responders/DataResponse/GeoTiffDR.java
@@ -58,18 +58,19 @@ public class GeoTiffDR extends Dap4Responder {
 
 
 
-    public GeoTiffDR(String sysPath, BesApi besApi) {
-        this(sysPath, null, defaultRequestSuffix, besApi);
+    public GeoTiffDR(String sysPath, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
+        this(sysPath, null, defaultRequestSuffix, besApi, addFileoutTypeSuffixToDownloadFilename);
     }
 
-    public GeoTiffDR(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath, pathPrefix, defaultRequestSuffix, besApi);
+    public GeoTiffDR(String sysPath, String pathPrefix, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
+        this(sysPath, pathPrefix, defaultRequestSuffix, besApi, addFileoutTypeSuffixToDownloadFilename);
     }
 
-    public GeoTiffDR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi) {
+    public GeoTiffDR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
+        addTypeSuffixToDownloadFilename(addFileoutTypeSuffixToDownloadFilename);
         setServiceRoleId("http://services.opendap.org/dap4/data/geotiff");
         setServiceTitle("GeoTIFF Data Response");
         setServiceDescription("GeoTIFF representation of the DAP4 Data Response object.");

--- a/src/opendap/bes/dap4Responders/DataResponse/GmlJpeg2000DR.java
+++ b/src/opendap/bes/dap4Responders/DataResponse/GmlJpeg2000DR.java
@@ -58,18 +58,19 @@ public class GmlJpeg2000DR extends Dap4Responder {
 
 
 
-    public GmlJpeg2000DR(String sysPath, BesApi besApi) {
-        this(sysPath, null, defaultRequestSuffix, besApi);
+    public GmlJpeg2000DR(String sysPath, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
+        this(sysPath, null, defaultRequestSuffix, besApi, addFileoutTypeSuffixToDownloadFilename);
     }
 
-    public GmlJpeg2000DR(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath, pathPrefix, defaultRequestSuffix, besApi);
+    public GmlJpeg2000DR(String sysPath, String pathPrefix, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
+        this(sysPath, pathPrefix, defaultRequestSuffix, besApi, addFileoutTypeSuffixToDownloadFilename);
     }
 
-    public GmlJpeg2000DR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi) {
+    public GmlJpeg2000DR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
+        addTypeSuffixToDownloadFilename(addFileoutTypeSuffixToDownloadFilename);
         setServiceRoleId("http://services.opendap.org/dap4/data/gmljp2");
         setServiceTitle("GML-JPEG2000 Data Response");
         setServiceDescription("GML-JPEG2000 representation of the DAP4 Data Response object.");

--- a/src/opendap/bes/dap4Responders/DataResponse/IjsonDR.java
+++ b/src/opendap/bes/dap4Responders/DataResponse/IjsonDR.java
@@ -59,18 +59,19 @@ public class IjsonDR extends Dap4Responder {
 
 
 
-    public IjsonDR(String sysPath, BesApi besApi) {
-        this(sysPath, null, defaultRequestSuffix, besApi);
+    public IjsonDR(String sysPath, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
+        this(sysPath, null, defaultRequestSuffix, besApi, addFileoutTypeSuffixToDownloadFilename);
     }
 
-    public IjsonDR(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath, pathPrefix, defaultRequestSuffix, besApi);
+    public IjsonDR(String sysPath, String pathPrefix, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
+        this(sysPath, pathPrefix, defaultRequestSuffix, besApi, addFileoutTypeSuffixToDownloadFilename);
     }
 
-    public IjsonDR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi) {
+    public IjsonDR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
+        addTypeSuffixToDownloadFilename(addFileoutTypeSuffixToDownloadFilename);
         setServiceRoleId("http://services.opendap.org/dap4/data/json");
         setServiceTitle("JSON Data Response");
         setServiceDescription("JSON representation of the DAP4 Data Response object.");

--- a/src/opendap/bes/dap4Responders/DataResponse/JsonDR.java
+++ b/src/opendap/bes/dap4Responders/DataResponse/JsonDR.java
@@ -55,18 +55,19 @@ public class JsonDR extends Dap4Responder {
 
 
 
-    public JsonDR(String sysPath, BesApi besApi) {
-        this(sysPath, null, defaultRequestSuffix, besApi);
+    public JsonDR(String sysPath, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
+        this(sysPath, null, defaultRequestSuffix, besApi, addFileoutTypeSuffixToDownloadFilename);
     }
 
-    public JsonDR(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath, pathPrefix, defaultRequestSuffix, besApi);
+    public JsonDR(String sysPath, String pathPrefix, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
+        this(sysPath, pathPrefix, defaultRequestSuffix, besApi, addFileoutTypeSuffixToDownloadFilename);
     }
 
-    public JsonDR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi) {
+    public JsonDR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
+        addTypeSuffixToDownloadFilename(addFileoutTypeSuffixToDownloadFilename);
         setServiceRoleId("http://services.opendap.org/dap4/data/json");
         setServiceTitle("JSON Data Response");
         setServiceDescription("JSON representation of the DAP4 Data Response object.");

--- a/src/opendap/bes/dap4Responders/DataResponse/Netcdf3DR.java
+++ b/src/opendap/bes/dap4Responders/DataResponse/Netcdf3DR.java
@@ -59,18 +59,19 @@ public class Netcdf3DR extends Dap4Responder{
 
 
 
-    public Netcdf3DR(String sysPath, BesApi besApi) {
-        this(sysPath, null, defaultRequestSuffix, besApi);
+    public Netcdf3DR(String sysPath, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, null, defaultRequestSuffix, besApi,addTypeSuffixToDownloadFilename);
     }
 
-    public Netcdf3DR(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath, pathPrefix, defaultRequestSuffix, besApi);
+    public Netcdf3DR(String sysPath, String pathPrefix, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, pathPrefix, defaultRequestSuffix, besApi,addTypeSuffixToDownloadFilename);
     }
 
-    public Netcdf3DR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi) {
+    public Netcdf3DR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
+        addTypeSuffixToDownloadFilename(addTypeSuffixToDownloadFilename);
         setServiceRoleId("http://services.opendap.org/dap4/data/netcdf-3");
         setServiceTitle("NetCDF-3 Data Response");
         setServiceDescription("NetCDF-3 representation of the DAP4 Data Response object.");
@@ -88,6 +89,17 @@ public class Netcdf3DR extends Dap4Responder{
     public boolean isMetadataResponder(){ return false; }
 
 
+
+    @Override
+    public String getDownloadFileName(String resourceID){
+
+        String downloadFileName = super.getDownloadFileName(resourceID);
+        Pattern startsWithNumber = Pattern.compile("[0-9].*");
+        if(startsWithNumber.matcher(downloadFileName).matches())
+            downloadFileName = "nc_"+downloadFileName;
+
+        return downloadFileName;
+    }
 
 
 
@@ -126,7 +138,6 @@ public class Netcdf3DR extends Dap4Responder{
         log.debug("respondToHttpGetRequest(): NetCDF file downloadFileName: " + downloadFileName );
 
         String contentDisposition = " attachment; filename=\"" +downloadFileName+"\"";
-
         response.setHeader("Content-Disposition", contentDisposition);
 
 

--- a/src/opendap/bes/dap4Responders/DataResponse/NormativeDR.java
+++ b/src/opendap/bes/dap4Responders/DataResponse/NormativeDR.java
@@ -67,19 +67,17 @@ public class NormativeDR extends Dap4Responder {
     //private String storedResultPrefix = "storedResults/";
 
 
-    public NormativeDR(String sysPath, BesApi besApi) {
-        this(sysPath, null, defaultRequestSuffix, besApi);
+    public NormativeDR(String sysPath, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, null, defaultRequestSuffix, besApi, addTypeSuffixToDownloadFilename);
     }
 
-    public NormativeDR(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath, pathPrefix, defaultRequestSuffix, besApi);
-    }
 
-    public NormativeDR(String sysPath, String pathPrefix, String requestSuffix, BesApi besApi) {
+    public NormativeDR(String sysPath, String pathPrefix, String requestSuffix, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffix, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
 
+        addTypeSuffixToDownloadFilename(addTypeSuffixToDownloadFilename);
         setServiceRoleId("http://services.opendap.org/dap4/data");
         setServiceTitle("DAP4 Data Response");
         setServiceDescription("DAP4 Data Response object.");
@@ -88,14 +86,14 @@ public class NormativeDR extends Dap4Responder {
 
         setNormativeMediaType(new Dap4Data(getRequestSuffix()));
 
-        addAltRepResponder(new CsvDR          (sysPath, pathPrefix, besApi));
-        addAltRepResponder(new XmlDR          (sysPath, pathPrefix, besApi));
-        addAltRepResponder(new Netcdf3DR      (sysPath, pathPrefix, besApi));
-        addAltRepResponder(new Netcdf4DR      (sysPath, pathPrefix, besApi));
-        addAltRepResponder(new GeoTiffDR      (sysPath, pathPrefix, besApi));
-        addAltRepResponder(new GmlJpeg2000DR  (sysPath, pathPrefix, besApi));
-        addAltRepResponder(new JsonDR         (sysPath, pathPrefix, besApi));
-        addAltRepResponder(new IjsonDR        (sysPath, pathPrefix, besApi));
+        addAltRepResponder(new CsvDR          (sysPath, pathPrefix, besApi, addTypeSuffixToDownloadFilename));
+        addAltRepResponder(new XmlDR          (sysPath, pathPrefix, besApi, addTypeSuffixToDownloadFilename));
+        addAltRepResponder(new Netcdf3DR      (sysPath, pathPrefix, besApi, addTypeSuffixToDownloadFilename));
+        addAltRepResponder(new Netcdf4DR      (sysPath, pathPrefix, besApi, addTypeSuffixToDownloadFilename));
+        addAltRepResponder(new GeoTiffDR      (sysPath, pathPrefix, besApi, addTypeSuffixToDownloadFilename));
+        addAltRepResponder(new GmlJpeg2000DR  (sysPath, pathPrefix, besApi, addTypeSuffixToDownloadFilename));
+        addAltRepResponder(new JsonDR         (sysPath, pathPrefix, besApi, addTypeSuffixToDownloadFilename));
+        addAltRepResponder(new IjsonDR        (sysPath, pathPrefix, besApi, addTypeSuffixToDownloadFilename));
 
 
         log.debug("Using RequestSuffix:              '{}'", getRequestSuffix());
@@ -135,6 +133,8 @@ public class NormativeDR extends Dap4Responder {
         // Commented because of a bug in the OPeNDAP C++ stuff...
         //response.setHeader("Content-Encoding", "plain");
 
+        String contentDisposition = " attachment; filename=\"" +getDownloadFileName(resourceID)+"\"";
+        response.setHeader("Content-Disposition", contentDisposition);
 
 
         MimeBoundary mb = new MimeBoundary();

--- a/src/opendap/bes/dap4Responders/DataResponse/XmlDR.java
+++ b/src/opendap/bes/dap4Responders/DataResponse/XmlDR.java
@@ -58,18 +58,19 @@ public class XmlDR extends Dap4Responder{
 
 
 
-    public XmlDR(String sysPath, BesApi besApi) {
-        this(sysPath, null, defaultRequestSuffix, besApi);
+    public XmlDR(String sysPath, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, null, defaultRequestSuffix, besApi, addTypeSuffixToDownloadFilename);
     }
 
-    public XmlDR(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath, pathPrefix, defaultRequestSuffix, besApi);
+    public XmlDR(String sysPath, String pathPrefix, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, pathPrefix, defaultRequestSuffix, besApi,addTypeSuffixToDownloadFilename);
     }
 
-    public XmlDR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi) {
+    public XmlDR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
+        addTypeSuffixToDownloadFilename(addTypeSuffixToDownloadFilename);
         setServiceRoleId("http://services.opendap.org/dap4/data/xml");
         setServiceTitle("XML Data Response");
         setServiceDescription("XML representation of the DAP4 Data Response object.");
@@ -113,6 +114,8 @@ public class XmlDR extends Dap4Responder{
         response.setHeader("Content-Description", getNormativeMediaType().getMimeType());
         // Commented because of a bug in the OPeNDAP C++ stuff...
         //response.setHeader("Content-Encoding", "plain");
+
+        response.setHeader("Content-Disposition", " attachment; filename=\"" +getDownloadFileName(resourceID)+"\"");
 
 
 

--- a/src/opendap/bes/dap4Responders/DatasetMetadata/IjsonDMR.java
+++ b/src/opendap/bes/dap4Responders/DatasetMetadata/IjsonDMR.java
@@ -58,18 +58,19 @@ public class IjsonDMR extends Dap4Responder {
 
 
 
-    public IjsonDMR(String sysPath, BesApi besApi) {
-        this(sysPath, null, defaultRequestSuffix, besApi);
+    public IjsonDMR(String sysPath, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, null, defaultRequestSuffix, besApi, addTypeSuffixToDownloadFilename);
     }
 
-    public IjsonDMR(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath, pathPrefix, defaultRequestSuffix, besApi);
+    public IjsonDMR(String sysPath, String pathPrefix, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, pathPrefix, defaultRequestSuffix, besApi, addTypeSuffixToDownloadFilename);
     }
 
-    public IjsonDMR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi) {
+    public IjsonDMR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
+        addTypeSuffixToDownloadFilename(addTypeSuffixToDownloadFilename);
         setServiceRoleId("http://services.opendap.org/dap4/data/json");
         setServiceTitle("JSON Metadadata Response");
         setServiceDescription("JSON representation of the DAP4 Dataset Metadata object.");

--- a/src/opendap/bes/dap4Responders/DatasetMetadata/JsonDMR.java
+++ b/src/opendap/bes/dap4Responders/DatasetMetadata/JsonDMR.java
@@ -59,18 +59,20 @@ public class JsonDMR extends Dap4Responder {
 
 
 
-    public JsonDMR(String sysPath, BesApi besApi) {
-        this(sysPath, null, defaultRequestSuffix, besApi);
+    public JsonDMR(String sysPath, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, null, defaultRequestSuffix, besApi, addTypeSuffixToDownloadFilename);
     }
 
-    public JsonDMR(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath, pathPrefix, defaultRequestSuffix, besApi);
+    public JsonDMR(String sysPath, String pathPrefix, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, pathPrefix, defaultRequestSuffix, besApi, addTypeSuffixToDownloadFilename);
     }
 
-    public JsonDMR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi) {
+
+    public JsonDMR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
+        addTypeSuffixToDownloadFilename(addTypeSuffixToDownloadFilename);
         setServiceRoleId("http://services.opendap.org/dap4/data/json");
         setServiceTitle("JSON Metadadata Response");
         setServiceDescription("JSON representation of the DAP4 Dataset Metadata object.");

--- a/src/opendap/bes/dap4Responders/DatasetMetadata/NormativeDMR.java
+++ b/src/opendap/bes/dap4Responders/DatasetMetadata/NormativeDMR.java
@@ -50,18 +50,20 @@ public class NormativeDMR extends Dap4Responder {
     private static String defaultRequestSuffix = ".dmr";
 
 
-    public NormativeDMR(String sysPath, BesApi besApi) {
-        this(sysPath, null, defaultRequestSuffix, besApi);
+    public NormativeDMR(String sysPath, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, null, defaultRequestSuffix, besApi, addTypeSuffixToDownloadFilename);
     }
 
-    public NormativeDMR(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath, pathPrefix, defaultRequestSuffix, besApi);
+    public NormativeDMR(String sysPath, String pathPrefix, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, pathPrefix, defaultRequestSuffix, besApi, addTypeSuffixToDownloadFilename);
     }
 
-    public NormativeDMR(String sysPath, String pathPrefix, String requestSuffix, BesApi besApi) {
+    public NormativeDMR(String sysPath, String pathPrefix, String requestSuffix, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffix, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
+
+        addTypeSuffixToDownloadFilename(addFileoutTypeSuffixToDownloadFilename);
         setServiceRoleId("http://services.opendap.org/dap4/dataset-metadata");
         setServiceTitle("Dataset Metadata Response");
         setServiceDescription("DAP4 Dataset Description and Attribute XML Document.");
@@ -69,11 +71,11 @@ public class NormativeDMR extends Dap4Responder {
 
         setNormativeMediaType(new DMR(getRequestSuffix()));
 
-        addAltRepResponder(new XmlDMR   (sysPath, pathPrefix, besApi));
+        addAltRepResponder(new XmlDMR   (sysPath, pathPrefix, besApi, addFileoutTypeSuffixToDownloadFilename));
         addAltRepResponder(new HtmlDMR  (sysPath, pathPrefix, besApi));
-        addAltRepResponder(new RdfDMR   (sysPath, pathPrefix, besApi));
-        addAltRepResponder(new JsonDMR  (sysPath, pathPrefix, besApi));
-        addAltRepResponder(new IjsonDMR (sysPath, pathPrefix, besApi));
+        addAltRepResponder(new RdfDMR   (sysPath, pathPrefix, besApi, addFileoutTypeSuffixToDownloadFilename));
+        addAltRepResponder(new JsonDMR  (sysPath, pathPrefix, besApi, addFileoutTypeSuffixToDownloadFilename));
+        addAltRepResponder(new IjsonDMR (sysPath, pathPrefix, besApi, addFileoutTypeSuffixToDownloadFilename));
 
         log.debug("Using RequestSuffix:              '{}'", getRequestSuffix());
         log.debug("Using CombinedRequestSuffixRegex: '{}'", getCombinedRequestSuffixRegex());

--- a/src/opendap/bes/dap4Responders/DatasetMetadata/RdfDMR.java
+++ b/src/opendap/bes/dap4Responders/DatasetMetadata/RdfDMR.java
@@ -63,18 +63,19 @@ public class RdfDMR extends Dap4Responder {
 
 
 
-    public RdfDMR(String sysPath, BesApi besApi) {
-        this(sysPath, null, defaultRequestSuffix, besApi);
+    public RdfDMR(String sysPath, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, null, defaultRequestSuffix, besApi, addTypeSuffixToDownloadFilename);
     }
 
-    public RdfDMR(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath, pathPrefix, defaultRequestSuffix, besApi);
+    public RdfDMR(String sysPath, String pathPrefix, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, pathPrefix, defaultRequestSuffix, besApi, addTypeSuffixToDownloadFilename);
     }
 
-    public RdfDMR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi) {
+    public RdfDMR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
+        addTypeSuffixToDownloadFilename(addTypeSuffixToDownloadFilename);
         setServiceRoleId("http://services.opendap.org/dap4/dataset-metadata");
         setServiceTitle("RDF representation of the DMR");
         setServiceDescription("RDF representation of the Dataset Metadata Response document.");
@@ -121,6 +122,7 @@ public class RdfDMR extends Dap4Responder {
         // Commented because of a bug in the OPeNDAP C++ stuff...
         //response.setHeader("Content-Encoding", "plain");
 
+        //response.setHeader("Content-Disposition", " attachment; filename=\"" +getDownloadFileName(resourceID)+"\"");
 
         XMLOutputter xmlo = new XMLOutputter(Format.getPrettyFormat());
 

--- a/src/opendap/bes/dap4Responders/DatasetMetadata/XmlDMR.java
+++ b/src/opendap/bes/dap4Responders/DatasetMetadata/XmlDMR.java
@@ -52,18 +52,19 @@ public class XmlDMR extends Dap4Responder {
 
 
 
-    public XmlDMR(String sysPath, BesApi besApi) {
-        this(sysPath,null, defaultRequestSuffix,besApi);
+    public XmlDMR(String sysPath, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath,null, defaultRequestSuffix,besApi, addTypeSuffixToDownloadFilename);
     }
 
-    public XmlDMR(String sysPath, String pathPrefix, BesApi besApi) {
-        this(sysPath, pathPrefix, defaultRequestSuffix, besApi);
+    public XmlDMR(String sysPath, String pathPrefix, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, pathPrefix, defaultRequestSuffix, besApi, addTypeSuffixToDownloadFilename);
     }
 
-    public XmlDMR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi) {
+    public XmlDMR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
         super(sysPath, pathPrefix, requestSuffixRegex, besApi);
         log = org.slf4j.LoggerFactory.getLogger(this.getClass());
 
+        addTypeSuffixToDownloadFilename(addTypeSuffixToDownloadFilename);
         setServiceRoleId("http://services.opendap.org/dap4/dataset-metadata");
         setServiceTitle("XML representation of the DMR.");
         setServiceDescription("Normative representation of the Dataset Metadata Response document with a generic content type.");
@@ -105,6 +106,7 @@ public class XmlDMR extends Dap4Responder {
         response.setContentType(responseMediaType.getMimeType());
         Version.setOpendapMimeHeaders(request,response,besApi);
         response.setHeader("Content-Description", getNormativeMediaType().getMimeType());
+        //response.setHeader("Content-Disposition", " attachment; filename=\"" +getDownloadFileName(resourceID)+"\"");
 
         OutputStream os = response.getOutputStream();
 

--- a/src/opendap/coreServlet/HttpResponder.java
+++ b/src/opendap/coreServlet/HttpResponder.java
@@ -170,6 +170,17 @@ public abstract class HttpResponder {
     }
 
 
+    /**
+     * Extract the 'filename' from the resourceID parameter. Assume that resourceID
+     * is a path in the Unix sense - a string with a series of names separated by 
+     * slashes ('/'). The characters following the last slash are the 'filename' part
+     * of the path. This method extracts those, performs a security 'scrub' and 
+     * returns the result.
+     * 
+     * @param resourceID A pathname or pathname-like string that names the subject
+     * of the current request.
+     * @return The filename part of the resourceID
+     */
     public String getDownloadFileName(String resourceID){
         String downloadFileName = Scrub.fileName(resourceID.substring(resourceID.lastIndexOf("/") + 1, resourceID.length()));
         log.debug("getDownloadFileName() - input: {} output: {}",resourceID,downloadFileName );


### PR DESCRIPTION
This is the new new filename behavior - if you ask for a 'nc' file and the basename is

1. file --> (you get) file.nc
2. file.nc --> file.nc
3. file.hdf --> file.nc
4. file.lots_of_text --> file.lots_of_text.nc

But, the code uses the old parameter/switch/key name ''addTypeSuffixToDownloadFilename()'' where True means you get the behavior above and False means you get the old behavior where the suffix is appended to whatever the name/resourceID was - the old old behavior. There could be a better name, but there could also be a worse name...

oh, I added some unit tests...