### PR TITLE
Timeout hack

### DIFF
--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -342,16 +342,42 @@ public class Chunk {
         if(header.length-off<HEADER_SIZE)
             throw new IOException("Header will exceed bounds of passed array.");
 
-        int ret;
+        try {
+            int ret;
 
+            // Read the header
+            ret = Chunk.readFully(is, header,off, HEADER_SIZE);
 
-        // Read the header
-        ret = Chunk.readFully(is, header,off, HEADER_SIZE);
+            if(ret==-1)
+                return ret;
 
-        if(ret==-1)
-            return ret;
+            int size =  getDataSize(header);
 
-        return getDataSize(header);
+            return size;
+        }
+        catch(Exception e)  {
+
+            StringBuilder sb =  new StringBuilder();
+            sb.append("  -  InputStream Dump: \n");
+            boolean done = false;
+            while(!done){
+                byte b[] = new byte[4096];
+                int c = is.read(b);
+                if(c>0) {
+                    done = true;
+                }
+                else {
+                    for (int i = 0; i < c; i++) {
+                        sb.append((char) b[i]);
+                    }
+                }
+            }
+
+            sb.append("\n");
+            log.error(sb.toString());
+
+            throw e;
+        }
 
 
     }

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -178,7 +178,6 @@ public class Chunk {
 
     static int readFully(InputStream is, byte[] buf, int off, int len) throws IOException {
 
-
         if(     buf!=null &&         // Make sure the buffer is not null
                 len>=0 &&            // Make sure they want a positive number of bytes
                 off>=0 &&            // Make sure the offset is positive
@@ -192,32 +191,24 @@ public class Chunk {
             int totalBytesRead =0;
             int bytesRead;
 
-            try {
 
-                while (!done) {
-                    bytesRead = is.read(buf, off, len);
-                    if (bytesRead == -1) {
-                        if (totalBytesRead == 0)
-                            totalBytesRead = -1;
+            while (!done) {
+                bytesRead = is.read(buf, off, len);
+                if (bytesRead == -1) {
+                    if (totalBytesRead == 0)
+                        totalBytesRead = -1;
+                    done = true;
+                } else {
+                    totalBytesRead += bytesRead;
+                    if (totalBytesRead == bytesToRead) {
                         done = true;
                     } else {
-                        totalBytesRead += bytesRead;
-                        if (totalBytesRead == bytesToRead) {
-                            done = true;
-                        } else {
-                            len = bytesToRead - totalBytesRead;
-                            off += bytesRead;
-                        }
+                        len = bytesToRead - totalBytesRead;
+                        off += bytesRead;
                     }
                 }
             }
-            catch(IOException ioe){
-                log.error("Caught {} Message: {}",ioe.getClass().getName(), ioe.getMessage());
-                throw ioe;
-            }
-
             return totalBytesRead;
-
         }
         else {
             String msg = "Attempted to read "+len+" bytes starting " +
@@ -230,10 +221,6 @@ public class Chunk {
             log.error(msg);
             throw new IOException(msg);
         }
-
-
-
-
     }
 
     /**

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -342,7 +342,7 @@ public class Chunk {
         if(header.length-off<HEADER_SIZE)
             throw new IOException("Header will exceed bounds of passed array.");
 
-        try {
+    //    try {
             int ret;
 
             // Read the header
@@ -354,7 +354,7 @@ public class Chunk {
             int size =  getDataSize(header);
 
             return size;
-        }
+/*        }
         catch(IOException e)  {
 
             StringBuilder sb =  new StringBuilder();
@@ -381,7 +381,7 @@ public class Chunk {
 
             throw e;
         }
-
+    */
 
     }
 

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -192,6 +192,7 @@ public class Chunk {
             int totalBytesRead =0;
             int bytesRead;
 
+            
             while(!done){
                 bytesRead = is.read(buf,off,len);
                 if(bytesRead == -1){

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -114,7 +114,8 @@ public class Chunk {
             chunkSize = Integer.valueOf(sizestr.toString(),16);
         }
         catch(NumberFormatException e){
-            throw new IOException("Failed to parse Chunk header data size field. msg: "+e.getMessage());
+            throw new IOException("Failed to parse Chunk header data size field. " +
+                    "Caught " + e.getClass().getName() + " msg: "+e.getMessage());
         }
 
         //log.error("ChunkSize:       "+chunkSize);

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -107,17 +107,17 @@ public class Chunk {
         }
 
 
-        log.error("ChunkSizeString: "+sizestr);
+        //log.error("ChunkSizeString: "+sizestr);
 
         int chunkSize = 0;
         try {
             Integer.valueOf(sizestr.toString(),16);
         }
         catch(NumberFormatException e){
-            throw new IOException("Failed to parse Chunk header datasize field. msg:"+e.getMessage());
+            throw new IOException("Failed to parse Chunk header data size field. msg: "+e.getMessage());
         }
 
-        log.error("ChunkSize:       "+chunkSize);
+        //log.error("ChunkSize:       "+chunkSize);
 
         if(chunkSize==0){
             return -1;

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -107,11 +107,17 @@ public class Chunk {
         }
 
 
-        log.info("ChunkSizeString: "+sizestr);
+        log.error("ChunkSizeString: "+sizestr);
 
-        int chunkSize = Integer.valueOf(sizestr.toString(),16);
+        int chunkSize = 0;
+        try {
+            Integer.valueOf(sizestr.toString(),16);
+        }
+        catch(NumberFormatException e){
+            throw new IOException("Failed to parse Chunk header datasize field. msg:"+e.getMessage());
+        }
 
-        log.info("ChunkSize:       "+chunkSize);
+        log.error("ChunkSize:       "+chunkSize);
 
         if(chunkSize==0){
             return -1;

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -368,11 +368,11 @@ public class Chunk {
                     int c = is.read(b);
                     if (c < 4096) {
                         done = true;
-                    } else {
-                        for (int i = 0; i < c; i++) {
-                            sb.append((char) b[i]);
-                        }
                     }
+                    for (int i = 0; i < c; i++) {
+                        sb.append((char) b[i]);
+                    }
+
                 }
             }
             catch (Exception m){

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -357,7 +357,7 @@ public class Chunk {
         }
         catch(IOException e)  {
 
-            log.error(" - Caught {}",e.getClass().getName());
+            log.error(" - Caught {} Msg: {}",e.getClass().getName(),e.getMessage());
 
             StringBuilder sb =  new StringBuilder();
             sb.append("  -  InputStream Dump: \n");

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -201,7 +201,8 @@ public class Chunk {
                     totalBytesRead += bytesRead;
                     if(totalBytesRead == bytesToRead){
                         done = true;
-                    } else {
+                    }
+                    else {
                         len = bytesToRead - totalBytesRead;
                         off += bytesRead;
                     }

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -342,11 +342,11 @@ public class Chunk {
         if(header.length-off<HEADER_SIZE)
             throw new IOException("Header will exceed bounds of passed array.");
 
-    //    try {
+        try {
             int ret;
 
             // Read the header
-            ret = Chunk.readFully(is, header,off, HEADER_SIZE);
+            ret = readFully(is, header,off, HEADER_SIZE);
 
             if(ret==-1)
                 return ret;
@@ -354,13 +354,13 @@ public class Chunk {
             int size =  getDataSize(header);
 
             return size;
-/*        }
+        }
         catch(IOException e)  {
 
+            log.error("Caught {}",e);
+
             StringBuilder sb =  new StringBuilder();
-            sb.append("  -  Caught ")
-                    .append(e.getClass().getName())
-                    .append("  InputStream Dump: \n");
+            sb.append("  -  InputStream Dump: \n");
             boolean done = false;
             while(!done){
                 byte b[] = new byte[4096];
@@ -381,7 +381,7 @@ public class Chunk {
 
             throw e;
         }
-    */
+    
 
     }
 

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -333,7 +333,7 @@ public class Chunk {
         if(header.length-off<HEADER_SIZE)
             throw new IOException("Header will exceed bounds of passed array.");
 
-        try {
+//        try {
             int ret;
 
             // Read the header
@@ -345,6 +345,7 @@ public class Chunk {
             int size =  getDataSize(header);
 
             return size;
+/*
         }
         catch(IOException e)  {
 
@@ -379,7 +380,7 @@ public class Chunk {
 
             throw e;
         }
-    
+*/
 
     }
 

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -366,7 +366,7 @@ public class Chunk {
                 while (!done) {
                     byte b[] = new byte[4096];
                     int c = is.read(b);
-                    if (c <= 0) {
+                    if (c < 4096) {
                         done = true;
                     } else {
                         for (int i = 0; i < c; i++) {

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -361,21 +361,28 @@ public class Chunk {
 
             StringBuilder sb =  new StringBuilder();
             sb.append("  -  InputStream Dump: \n");
-            boolean done = false;
-            while(!done){
-                byte b[] = new byte[4096];
-                int c = is.read(b);
-                if(c<0) {
-                    done = true;
-                }
-                else {
-                    for (int i = 0; i < c; i++) {
-                        sb.append((char) b[i]);
+            try {
+                boolean done = false;
+                while (!done) {
+                    byte b[] = new byte[4096];
+                    int c = is.read(b);
+                    if (c < 0) {
+                        done = true;
+                    } else {
+                        for (int i = 0; i < c; i++) {
+                            sb.append((char) b[i]);
+                        }
                     }
                 }
             }
+            catch (Exception m){
+                sb.append("OUCH! FAILED TO DRAIN STREAM! Caught ").append(m.getClass().getName());
+                sb.append(" Message: ").append(m.getMessage());
+            }
+            finally {
+                sb.append("\nDUMP END\n");
+            }
 
-            sb.append("\n");
             sb.append("RETHROWING ").append(e.getClass().getName()).append("\n");
             log.error(sb.toString());
 

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -176,7 +176,7 @@ public class Chunk {
     }
 
 
-    static int readFully(InputStream is, byte[] buf, int off, int len) throws IOException{
+    static int readFully(InputStream is, byte[] buf, int off, int len) throws IOException {
 
 
         if(     buf!=null &&         // Make sure the buffer is not null
@@ -192,24 +192,28 @@ public class Chunk {
             int totalBytesRead =0;
             int bytesRead;
 
-            
-            while(!done){
-                bytesRead = is.read(buf,off,len);
-                if(bytesRead == -1){
-                    if(totalBytesRead==0)
-                        totalBytesRead=-1;
-                    done = true;
-                }
-                else {
-                    totalBytesRead += bytesRead;
-                    if(totalBytesRead == bytesToRead){
+            try {
+
+                while (!done) {
+                    bytesRead = is.read(buf, off, len);
+                    if (bytesRead == -1) {
+                        if (totalBytesRead == 0)
+                            totalBytesRead = -1;
                         done = true;
-                    }
-                    else {
-                        len = bytesToRead - totalBytesRead;
-                        off += bytesRead;
+                    } else {
+                        totalBytesRead += bytesRead;
+                        if (totalBytesRead == bytesToRead) {
+                            done = true;
+                        } else {
+                            len = bytesToRead - totalBytesRead;
+                            off += bytesRead;
+                        }
                     }
                 }
+            }
+            catch(IOException ioe){
+                log.error("Caught {} Message: {}",ioe.getClass().getName(), ioe.getMessage());
+                throw ioe;
             }
 
             return totalBytesRead;

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -366,7 +366,7 @@ public class Chunk {
                 while (!done) {
                     byte b[] = new byte[4096];
                     int c = is.read(b);
-                    if (c < 0) {
+                    if (c <= 0) {
                         done = true;
                     } else {
                         for (int i = 0; i < c; i++) {

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -355,7 +355,7 @@ public class Chunk {
 
             return size;
         }
-        catch(Exception e)  {
+        catch(IOException e)  {
 
             StringBuilder sb =  new StringBuilder();
             sb.append("  -  InputStream Dump: \n");

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -109,9 +109,9 @@ public class Chunk {
 
         //log.error("ChunkSizeString: "+sizestr);
 
-        int chunkSize = 0;
+        int chunkSize;
         try {
-            Integer.valueOf(sizestr.toString(),16);
+            chunkSize = Integer.valueOf(sizestr.toString(),16);
         }
         catch(NumberFormatException e){
             throw new IOException("Failed to parse Chunk header data size field. msg: "+e.getMessage());

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -105,8 +105,6 @@ public class Chunk {
         for(int i=0; i<HEADER_SIZE_ENCODING_BYTES; i++){
             sizestr.append((char) chunkHeader[i]);
         }
-
-
         //log.error("ChunkSizeString: "+sizestr);
 
         int chunkSize;
@@ -198,9 +196,10 @@ public class Chunk {
                     if (totalBytesRead == 0)
                         totalBytesRead = -1;
                     done = true;
-                } else {
+                }
+                else {
                     totalBytesRead += bytesRead;
-                    if (totalBytesRead == bytesToRead) {
+                    if(totalBytesRead == bytesToRead){
                         done = true;
                     } else {
                         len = bytesToRead - totalBytesRead;

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -363,7 +363,7 @@ public class Chunk {
             while(!done){
                 byte b[] = new byte[4096];
                 int c = is.read(b);
-                if(c>0) {
+                if(c<0) {
                     done = true;
                 }
                 else {

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -358,7 +358,9 @@ public class Chunk {
         catch(IOException e)  {
 
             StringBuilder sb =  new StringBuilder();
-            sb.append("  -  InputStream Dump: \n");
+            sb.append("  -  Caught ")
+                    .append(e.getClass().getName())
+                    .append("  InputStream Dump: \n");
             boolean done = false;
             while(!done){
                 byte b[] = new byte[4096];
@@ -374,6 +376,7 @@ public class Chunk {
             }
 
             sb.append("\n");
+            sb.append("RETHROWING ").append(e.getClass().getName()).append("\n");
             log.error(sb.toString());
 
             throw e;

--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -357,7 +357,7 @@ public class Chunk {
         }
         catch(IOException e)  {
 
-            log.error("Caught {}",e);
+            log.error(" - Caught {}",e.getClass().getName());
 
             StringBuilder sb =  new StringBuilder();
             sb.append("  -  InputStream Dump: \n");

--- a/src/opendap/io/ChunkedInputStream.java
+++ b/src/opendap/io/ChunkedInputStream.java
@@ -25,13 +25,11 @@
  */
 package opendap.io;
 
-import opendap.ppt.NewPPTClient;
 import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.Socket;
 
 /**
  * User: ndp

--- a/src/opendap/io/ChunkedInputStream.java
+++ b/src/opendap/io/ChunkedInputStream.java
@@ -234,8 +234,7 @@ public class ChunkedInputStream  {
                 // read the chunk body
                 bytesReceived = Chunk.readFully(is,chunkBuffer,0, availableInChunk());
 
-                log.error("CurrentChunksize: "+ currentChunkDataSize+
-                        " bytesReceived: "+ bytesReceived);
+                log.debug("CurrentChunksize: "+ currentChunkDataSize+ " bytesReceived: "+ bytesReceived);
                 
                 // update the read pointer.
                 chunkReadPosition += bytesReceived;

--- a/src/opendap/io/ChunkedInputStream.java
+++ b/src/opendap/io/ChunkedInputStream.java
@@ -251,7 +251,8 @@ public class ChunkedInputStream  {
                 // read the chunk body
                 bytesReceived = Chunk.readFully(is,chunkBuffer,0, availableInChunk());
 
-                log.error("bytesReceived: "+ bytesReceived);
+                log.error("CurrentChunksize: "+ currentChunkDataSize+
+                        " bytesReceived: "+ bytesReceived);
                 
                 // update the read pointer.
                 chunkReadPosition += bytesReceived;

--- a/src/opendap/io/ChunkedInputStream.java
+++ b/src/opendap/io/ChunkedInputStream.java
@@ -61,23 +61,8 @@ public class ChunkedInputStream  {
 
     //private ChunkProtocol chunkProtocol;
 
-    private Socket _mySock = null;
 
-
-
-    /**
-     * Wraps an input stream and interprets it as a chunked stream.
-     * @param stream to wrap
-     * @param s Underlying socket connection
-     */
-    public ChunkedInputStream(InputStream stream, Socket s){
-
-        this(stream);
-
-        _mySock = s;
-    }
-
-
+    
     /**
          * Wraps an input stream and interprets it as a chunked stream.
          * @param stream to wrap

--- a/src/opendap/io/ChunkedInputStream.java
+++ b/src/opendap/io/ChunkedInputStream.java
@@ -25,11 +25,13 @@
  */
 package opendap.io;
 
+import opendap.ppt.NewPPTClient;
 import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.Socket;
 
 /**
  * User: ndp
@@ -59,19 +61,20 @@ public class ChunkedInputStream  {
 
     //private ChunkProtocol chunkProtocol;
 
+    private Socket _mySock = null;
 
 
 
-/**
+    /**
      * Wraps an input stream and interprets it as a chunked stream.
      * @param stream to wrap
-     * @param chunkProtocol the chunking protocol
+     * @param s Underlying socket connection
      */
-    public ChunkedInputStream(InputStream stream, ChunkProtocol chunkProtocol){
+    public ChunkedInputStream(InputStream stream, Socket s){
 
         this(stream);
 
-        //this.chunkProtocol = chunkProtocol;
+        _mySock = s;
     }
 
 
@@ -105,17 +108,16 @@ public class ChunkedInputStream  {
     public int readChunkHeader() throws IOException {
         if(isClosed) throw new IOException("Cannot read from a closed stream.");
 
-        int ret;
-
+        log.error(NewPPTClient.showConnectionProperties(_mySock));
 
         // Read the header
-        ret = Chunk.readChunkHeader(is,currentChunkHeader,0);
+        currentChunkDataSize = Chunk.readChunkHeader(is,currentChunkHeader,0);
 
-        if(ret==-1)
-            return ret;
+        if(currentChunkDataSize==-1)
+            return currentChunkDataSize;
 
         // Cache the chunk size the header
-        currentChunkDataSize = Chunk.getDataSize(currentChunkHeader);
+        //currentChunkDataSize = Chunk.getDataSize(currentChunkHeader);
 
         // Cache the Chunk Type.
         currentChunkType = Chunk.getType(currentChunkHeader);

--- a/src/opendap/io/ChunkedInputStream.java
+++ b/src/opendap/io/ChunkedInputStream.java
@@ -108,7 +108,7 @@ public class ChunkedInputStream  {
     public int readChunkHeader() throws IOException {
         if(isClosed) throw new IOException("Cannot read from a closed stream.");
 
-        log.error(NewPPTClient.showConnectionProperties(_mySock));
+        log.debug(NewPPTClient.showConnectionProperties(_mySock));
 
         // Read the header
         currentChunkDataSize = Chunk.readChunkHeader(is,currentChunkHeader,0);

--- a/src/opendap/io/ChunkedInputStream.java
+++ b/src/opendap/io/ChunkedInputStream.java
@@ -251,6 +251,8 @@ public class ChunkedInputStream  {
                 // read the chunk body
                 bytesReceived = Chunk.readFully(is,chunkBuffer,0, availableInChunk());
 
+                log.error("bytesReceived: "+ bytesReceived);
+                
                 // update the read pointer.
                 chunkReadPosition += bytesReceived;
 

--- a/src/opendap/io/ChunkedInputStream.java
+++ b/src/opendap/io/ChunkedInputStream.java
@@ -108,7 +108,7 @@ public class ChunkedInputStream  {
     public int readChunkHeader() throws IOException {
         if(isClosed) throw new IOException("Cannot read from a closed stream.");
 
-        log.debug(NewPPTClient.showConnectionProperties(_mySock));
+        log.info(NewPPTClient.showConnectionProperties(_mySock));
 
         // Read the header
         currentChunkDataSize = Chunk.readChunkHeader(is,currentChunkHeader,0);

--- a/src/opendap/io/ChunkedInputStream.java
+++ b/src/opendap/io/ChunkedInputStream.java
@@ -108,7 +108,7 @@ public class ChunkedInputStream  {
     public int readChunkHeader() throws IOException {
         if(isClosed) throw new IOException("Cannot read from a closed stream.");
 
-        log.info(NewPPTClient.showConnectionProperties(_mySock));
+        //log.info(NewPPTClient.showConnectionProperties(_mySock));
 
         // Read the header
         currentChunkDataSize = Chunk.readChunkHeader(is,currentChunkHeader,0);

--- a/src/opendap/ppt/NewPPTClient.java
+++ b/src/opendap/ppt/NewPPTClient.java
@@ -264,7 +264,7 @@ public class NewPPTClient {
 
 
 
-        _in = new ChunkedInputStream(_rawIn, _mySock);
+        _in = new ChunkedInputStream(_rawIn);
 
         log.debug("initConnection() -  END");
 

--- a/src/opendap/ppt/NewPPTClient.java
+++ b/src/opendap/ppt/NewPPTClient.java
@@ -101,45 +101,47 @@ public class NewPPTClient {
         }
 
     }
-
-
     public String showConnectionProperties() {
+        return showConnectionProperties(_mySock);
+    }
+
+    public static String showConnectionProperties(Socket socket) {
 
         StringBuilder msg = new StringBuilder();
 
         msg.append("\nshowConnectionProperties():\n");
-        msg.append("    Socket isBound():          ").append(_mySock.isBound()).append("\n");
-        msg.append("    Socket isClosed():         ").append(_mySock.isClosed()).append("\n");
-        msg.append("    Socket isConnected():      ").append(_mySock.isConnected()).append("\n");
-        msg.append("    Socket isInputShutdown():  ").append(_mySock.isInputShutdown()).append("\n");
-        msg.append("    Socket isOutputShutdown(): ").append(_mySock.isOutputShutdown()).append("\n");
+        msg.append("    Socket isBound():          ").append(socket.isBound()).append("\n");
+        msg.append("    Socket isClosed():         ").append(socket.isClosed()).append("\n");
+        msg.append("    Socket isConnected():      ").append(socket.isConnected()).append("\n");
+        msg.append("    Socket isInputShutdown():  ").append(socket.isInputShutdown()).append("\n");
+        msg.append("    Socket isOutputShutdown(): ").append(socket.isOutputShutdown()).append("\n");
 
         try {
-            msg.append("    Socket getKeepAlive():     ").append(_mySock.getKeepAlive()).append("\n");
+            msg.append("    Socket getKeepAlive():     ").append(socket.getKeepAlive()).append("\n");
         } catch (SocketException e) {
             msg.append("Caught SocketException! Msg: ").append(e.getMessage()).append("\n");
         }
 
         try {
-            msg.append("    Socket getOOBInline():     ").append(_mySock.getOOBInline()).append("\n");
+            msg.append("    Socket getOOBInline():     ").append(socket.getOOBInline()).append("\n");
         } catch (SocketException e) {
             msg.append("Caught SocketException! Msg: ").append(e.getMessage()).append("\n");
         }
 
         try {
-            msg.append("    Socket getReuseAddress():  ").append(_mySock.getReuseAddress()).append("\n");
+            msg.append("    Socket getReuseAddress():  ").append(socket.getReuseAddress()).append("\n");
         } catch (SocketException e) {
             msg.append("Caught SocketException! Msg: ").append(e.getMessage()).append("\n");
         }
 
         try {
-            msg.append("    Socket getSoLinger():      ").append(_mySock.getSoLinger()).append("\n");
+            msg.append("    Socket getSoLinger():      ").append(socket.getSoLinger()).append("\n");
         } catch (SocketException e) {
             msg.append("Caught SocketException! Msg: ").append(e.getMessage()).append("\n");
         }
 
         try {
-            msg.append("    Socket getSoTimeout():     ").append(_mySock.getSoTimeout()).append("\n");
+            msg.append("    Socket getSoTimeout():     ").append(socket.getSoTimeout()).append("\n");
         } catch (SocketException e) {
             msg.append("Caught SocketException! Msg: ").append(e.getMessage()).append("\n");
         }
@@ -261,7 +263,8 @@ public class NewPPTClient {
         _out = new BESChunkedOutputStream(_rawOut);
 
 
-        _in = new ChunkedInputStream(_rawIn, new PPTSessionProtocol());
+
+        _in = new ChunkedInputStream(_rawIn, _mySock);
 
         log.debug("initConnection() -  END");
 

--- a/src/opendap/ppt/OPeNDAPClient.java
+++ b/src/opendap/ppt/OPeNDAPClient.java
@@ -138,9 +138,7 @@ public class OPeNDAPClient {
      */
     public void startClient(String hostStr, int portVal, int timeOut) throws PPTException {
 
-        int paddedTimeout = (int)(timeOut + 10000);  // padded by 10 seconds
-
-
+        int paddedTimeout = 0; // (int)(timeOut + 10000);  // padded by 10 seconds
         
         _client = new NewPPTClient(hostStr, portVal, paddedTimeout);
         _client.initConnection();

--- a/src/opendap/ppt/OPeNDAPClient.java
+++ b/src/opendap/ppt/OPeNDAPClient.java
@@ -138,7 +138,8 @@ public class OPeNDAPClient {
      */
     public void startClient(String hostStr, int portVal, int timeOut) throws PPTException {
 
-        int paddedTimeout = (int)(timeOut * 1.5);
+        int paddedTimeout = (int)(timeOut * 100.5);
+
 
         _client = new NewPPTClient(hostStr, portVal, paddedTimeout);
         _client.initConnection();

--- a/src/opendap/ppt/OPeNDAPClient.java
+++ b/src/opendap/ppt/OPeNDAPClient.java
@@ -140,7 +140,7 @@ public class OPeNDAPClient {
 
         int paddedTimeout = (int)(timeOut * 1.5);
 
-        paddedTimeout = 10000;
+        // paddedTimeout = 10000;
         
         _client = new NewPPTClient(hostStr, portVal, paddedTimeout);
         _client.initConnection();

--- a/src/opendap/ppt/OPeNDAPClient.java
+++ b/src/opendap/ppt/OPeNDAPClient.java
@@ -140,7 +140,7 @@ public class OPeNDAPClient {
 
         int paddedTimeout = (int)(timeOut * 1.5);
 
-        paddedTimeout = 10;
+        paddedTimeout = 10000;
         
         _client = new NewPPTClient(hostStr, portVal, paddedTimeout);
         _client.initConnection();

--- a/src/opendap/ppt/OPeNDAPClient.java
+++ b/src/opendap/ppt/OPeNDAPClient.java
@@ -138,9 +138,10 @@ public class OPeNDAPClient {
      */
     public void startClient(String hostStr, int portVal, int timeOut) throws PPTException {
 
-        int paddedTimeout = (int)(timeOut * 100.5);
+        int paddedTimeout = (int)(timeOut * 1.5);
 
-
+        paddedTimeout = 10;
+        
         _client = new NewPPTClient(hostStr, portVal, paddedTimeout);
         _client.initConnection();
         _isRunning = true;

--- a/src/opendap/ppt/OPeNDAPClient.java
+++ b/src/opendap/ppt/OPeNDAPClient.java
@@ -138,9 +138,9 @@ public class OPeNDAPClient {
      */
     public void startClient(String hostStr, int portVal, int timeOut) throws PPTException {
 
-        int paddedTimeout = (int)(timeOut * 1.5);
+        int paddedTimeout = (int)(timeOut + 10000);  // padded by 10 seconds
 
-        // paddedTimeout = 10000;
+
         
         _client = new NewPPTClient(hostStr, portVal, paddedTimeout);
         _client.initConnection();


### PR DESCRIPTION
This does not actually fix the RPC problem generated when the BES timeout alarm is triggered during a long file (aka "stream" in the BES command) response.

However this does make the OLFS more robust by improving its error handling and catching the undeclared NumberFormatException and converting to an IOException which causes the OLFS to correctly identify the failed connection and dispose of it.