### PR TITLE
Wcs bes

### DIFF
--- a/resources/WCS/2.0/xsl/capabilities.xsl
+++ b/resources/WCS/2.0/xsl/capabilities.xsl
@@ -35,7 +35,8 @@
                 xmlns:gml="http://www.opengis.net/gml/3.2"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
         >
-    <xsl:param name="ServicePrefix" />
+    <xsl:param name="WcsService" />
+    <xsl:param name="DocsService" />
     <xsl:param name="UpdateIsRunning"/>
     <xsl:output method='html' version='1.0' encoding='UTF-8' indent='yes'/>
 
@@ -52,7 +53,7 @@
                 <xsl:element name="link">
                     <xsl:attribute name="rel">stylesheet</xsl:attribute>
                     <xsl:attribute name="type">text/css</xsl:attribute>
-                    <xsl:attribute name="href"><xsl:value-of select="$ServicePrefix"/>/docs/css/contents.css</xsl:attribute>
+                    <xsl:attribute name="href"><xsl:value-of select="$DocsService"/>/css/contents.css</xsl:attribute>
                 </xsl:element>
 
                 <xsl:choose>
@@ -77,7 +78,7 @@
 
                 <table border="0" width="90%"><tr>
 
-                    <td><img alt="Institution Logo" src="{concat($ServicePrefix,'/docs/images/logo.gif')}" /></td>
+                    <td><img alt="Institution Logo" src="{concat($DocsService,'/images/logo.gif')}" /></td>
 
                     <td align="center"><div  class="xlarge"> Web Coverage Service</div></td>
 
@@ -131,13 +132,13 @@
                 <div class= "medium">
                 <ul>
                     <li>
-                        <a href="{$ServicePrefix}/test?service=WCS&amp;request=GetCapabilities">KVP Test Page</a>
+                        <a href="{$WcsService}/test?service=WCS&amp;request=GetCapabilities">KVP Test Page</a>
                         - Parses a KVP request and returns a page
                         reporting any problems.
                     </li>
                     <br/>
                     <li>
-                        <a href="{$ServicePrefix}/echoXML?service=WCS&amp;request=GetCapabilities">Return KVP as XML</a>
+                        <a href="{$WcsService}/echoXML?service=WCS&amp;request=GetCapabilities">Return KVP as XML</a>
                         - Translates a KVP encoded request into
                         an XML encoded version of the request.
                     </li>
@@ -151,7 +152,7 @@
                 <br/>
                 A WCS response will be returned.
 
-                <form action="{$ServicePrefix}/form" method="post">
+                <form action="{$WcsService}/form" method="post">
                     <p>
                         <textarea name="WCS_QUERY" rows="20" cols="80">Insert your WCS query here...</textarea>
                     </p>
@@ -314,7 +315,7 @@
             <td align="left">
                 <xsl:element name="a">
                     <xsl:attribute name="href">
-                        <xsl:value-of select="$ServicePrefix"/>/describeCoverage?<xsl:value-of select="wcs:CoverageId"/>
+                        <xsl:value-of select="$WcsService"/>/describeCoverage?<xsl:value-of select="wcs:CoverageId"/>
                     </xsl:attribute>
                     <xsl:choose>
                         <xsl:when test="ows:Title">
@@ -359,7 +360,7 @@
                 <xsl:element name="a">
                     <xsl:attribute name="href">
                         <!-- xsl:value-of select="$ServicePrefix"/>/describeCoverage?<xsl:value-of select="wcseo:DatasetSeriesId"/ -->
-                        <xsl:value-of select="$ServicePrefix"/>?service=WCS&amp;version=2.0.1&amp;request=DescribeEOCoverageSet&amp;eoId=<xsl:value-of select="wcseo:DatasetSeriesId"/>
+                        <xsl:value-of select="$WcsService"/>?service=WCS&amp;version=2.0.1&amp;request=DescribeEOCoverageSet&amp;eoId=<xsl:value-of select="wcseo:DatasetSeriesId"/>
 
                         <!--
                         http://localhost:8080/WCS-2.0?service=WCS&version=2.0.1&request=DescribeCoverage&coverageId=MODIS_AQUA_L3_CHLA_DAILY_4KM_R_002_nc4_min_eo

--- a/resources/WCS/2.0/xsl/coverageDescription.xsl
+++ b/resources/WCS/2.0/xsl/coverageDescription.xsl
@@ -35,7 +35,8 @@
                 xmlns:gmlcov="http://www.opengis.net/gmlcov/1.0"
                 xmlns:swe="http://www.opengis.net/swe/2.0"
         >
-    <xsl:param name="ServicePrefix" />
+    <xsl:param name="WcsService" />
+    <xsl:param name="DocsService" />
     <xsl:param name="UpdateIsRunning"/>
     <xsl:output method='xml' version='1.0' encoding='UTF-8' indent='yes'/>
 
@@ -53,7 +54,7 @@
                 <xsl:element name="link">
                     <xsl:attribute name="rel">stylesheet</xsl:attribute>
                     <xsl:attribute name="type">text/css</xsl:attribute>
-                    <xsl:attribute name="href"><xsl:value-of select="$ServicePrefix"/>/docs/css/contents.css</xsl:attribute>
+                    <xsl:attribute name="href"><xsl:value-of select="$DocsService"/>/css/contents.css</xsl:attribute>
                 </xsl:element>
                 <title>OPeNDAP: Web Coverage Service</title>
             </head>
@@ -66,7 +67,7 @@
 
                 <table border="0" width="90%">
                     <tr>
-                        <td><img alt="Institution Logo" src="{concat($ServicePrefix,'/docs/images/logo.gif')}" /></td>
+                        <td><img alt="Institution Logo" src="{concat($DocsService,'/images/logo.gif')}" /></td>
                         <td align="center">
                             <div  class="xlarge">Web Coverage Service</div>
                         </td>
@@ -88,7 +89,7 @@
                 </xsl:if>
                 <h2>
                     <span align="left" class="small">wcs:</span>Coverage Description
-                    <a href="{$ServicePrefix}?service=WCS&amp;version=2.0.1&amp;request=DescribeCoverage&amp;coverageId={wcs:CoverageId}"><span class="small">XML</span></a>
+                    <a href="{$WcsService}?service=WCS&amp;version=2.0.1&amp;request=DescribeCoverage&amp;coverageId={wcs:CoverageId}"><span class="small">XML</span></a>
                 </h2>
 
 
@@ -333,7 +334,7 @@
                 <xsl:element name="link">
                     <xsl:attribute name="rel">stylesheet</xsl:attribute>
                     <xsl:attribute name="type">text/css</xsl:attribute>
-                    <xsl:attribute name="href"><xsl:value-of select="$ServicePrefix"/>/docs/css/contents.css</xsl:attribute>
+                    <xsl:attribute name="href"><xsl:value-of select="$DocsService"/>/css/contents.css</xsl:attribute>
                 </xsl:element>
                 <title>OPeNDAP: Web Coverage Service Exception</title>
             </head>
@@ -346,7 +347,7 @@
 
                 <table border="0" width="90%">
                     <tr>
-                        <td><img alt="Institution Logo" src="{concat($ServicePrefix,'/docs/images/logo.gif')}" /></td>
+                        <td><img alt="Institution Logo" src="{concat($DocsService,'/images/logo.gif')}" /></td>
                         <td align="center">
                             <div  class="xlarge">Web Coverage Service Exception</div>
                         </td>

--- a/resources/WCS/2.0/xsl/wcsException.xsl
+++ b/resources/WCS/2.0/xsl/wcsException.xsl
@@ -28,6 +28,7 @@
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:ows="http://www.opengis.net/ows/2.0"
         >
+    <xsl:param name="DocsService" />
 
     <xsl:template match="/ows:WcsExceptionReport">
         <html>
@@ -35,7 +36,7 @@
                 <xsl:element name="link">
                     <xsl:attribute name="rel">stylesheet</xsl:attribute>
                     <xsl:attribute name="type">text/css</xsl:attribute>
-                    <xsl:attribute name="href"><xsl:value-of select="$ServicePrefix"/>/docs/css/contents.css</xsl:attribute>
+                    <xsl:attribute name="href"><xsl:value-of select="$DocsService"/>/css/contents.css</xsl:attribute>
                 </xsl:element>
                 <title>OPeNDAP: Web Coverage Service Exception</title>
             </head>

--- a/resources/hyrax/WEB-INF/urlrewrite.xml
+++ b/resources/hyrax/WEB-INF/urlrewrite.xml
@@ -35,7 +35,7 @@
     </rule>
 
     <rule>
-        <from>^/(admin|pdpService|hai|error|docs|jsp|viewers|xsl|hyrax|w10n|servlet_gateway|js|aggregation)(/.*)?$</from>
+        <from>^/(wcs|admin|pdpService|hai|error|docs|jsp|viewers|xsl|hyrax|w10n|servlet_gateway|js|aggregation)(/.*)?$</from>
         <set name="doRedirect">0</set>
     </rule>
 

--- a/resources/hyrax/WEB-INF/web.xml
+++ b/resources/hyrax/WEB-INF/web.xml
@@ -175,6 +175,20 @@
         <load-on-startup>1</load-on-startup>
 
     </servlet>
+
+    <!-- - - - - - - - - WCS Servlet - - - - - - - - - -->
+    <servlet>
+        <servlet-name>wcs</servlet-name>
+        <servlet-class>opendap.wcs.v2_0.http.Servlet</servlet-class>
+        <init-param>
+            <param-name>WCSConfigFileName</param-name>
+            <param-value>wcs_service.xml</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - -->
+
+
     <servlet>
         <servlet-name>w10n</servlet-name>
         <servlet-class>opendap.w10n.W10nServlet</servlet-class>
@@ -277,7 +291,12 @@
         <url-pattern>/w10n/*</url-pattern>
     </servlet-mapping>
 
-  <!-- ==================== Default Session Configuration ================= -->
+    <servlet-mapping>
+        <servlet-name>wcs</servlet-name>
+        <url-pattern>/wcs/*</url-pattern>
+    </servlet-mapping>
+
+    <!-- ==================== Default Session Configuration ================= -->
   <!-- You can set the default session timeout (in minutes) for all newly   -->
   <!-- created sessions by modifying the value below.                       -->
 

--- a/src/opendap/bes/dap2Responders/Netcdf3.java
+++ b/src/opendap/bes/dap2Responders/Netcdf3.java
@@ -111,7 +111,7 @@ public class Netcdf3 extends Dap4Responder {
 
         String resourceID = getResourceId(requestedResourceId, false);
 
-        String cf_history_entry = getCFHistoryEntry(request);
+        String cf_history_entry = ReqInfo.getCFHistoryEntry(request);
 
         log.debug("sendNormativeRepresentation(): cf_history_entry: '{}'",cf_history_entry);
 

--- a/src/opendap/bes/dap2Responders/Netcdf4.java
+++ b/src/opendap/bes/dap2Responders/Netcdf4.java
@@ -106,7 +106,7 @@ public class Netcdf4 extends Dap4Responder {
 
         String resourceID = getResourceId(requestedResourceId, false);
 
-        String cf_history_entry = getCFHistoryEntry(request);
+        String cf_history_entry = ReqInfo.getCFHistoryEntry(request);
 
         BesApi besApi = getBesApi();
 

--- a/src/opendap/bes/dap4Responders/Dap4Responder.java
+++ b/src/opendap/bes/dap4Responders/Dap4Responder.java
@@ -40,11 +40,10 @@ import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.text.FieldPosition;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.regex.Pattern;
+
 
 /**
  * Created by IntelliJ IDEA.
@@ -387,6 +386,7 @@ public abstract class Dap4Responder extends BesDapResponder  {
 
     */
 
+    /*
 
     public String getRequestUrlPath(HttpServletRequest req) {
         String forwardRequestUri = (String)req.getAttribute("javax.servlet.forward.request_uri");
@@ -403,12 +403,12 @@ public abstract class Dap4Responder extends BesDapResponder  {
         return requestUrl;
     }
 
-
+     */
 
     @Override
     public String getXmlBase(HttpServletRequest req){
 
-        String requestUrl = getRequestUrlPath(req);
+        String requestUrl = ReqInfo.getRequestUrlPath(req);
         String xmlBase = Util.dropSuffixFrom(requestUrl, Pattern.compile(getCombinedRequestSuffixRegex()));
         _log.debug("getXmlBase(): @xml:base='{}'", xmlBase);
         return xmlBase;
@@ -430,9 +430,11 @@ public abstract class Dap4Responder extends BesDapResponder  {
     }
 
 
+    /*
+
     private static final String CF_History_Entry_Date_Format = "yyyy-MM-dd HH:mm:ss z";
 
-    public String getCFHistoryEntry(HttpServletRequest request) throws IOException {
+    public  String getCFHistoryEntry(HttpServletRequest request) throws IOException {
 
         StringBuilder cf_history_entry = new StringBuilder();
 
@@ -449,7 +451,7 @@ public abstract class Dap4Responder extends BesDapResponder  {
         cf_history_entry.append(" ");
 
         // Add the complete request URL
-        cf_history_entry.append(getRequestUrlPath(request));
+        cf_history_entry.append(ReqInfo.getRequestUrlPath(request));
         cf_history_entry.append("?");
         cf_history_entry.append(ReqInfo.getConstraintExpression(request));
         cf_history_entry.append("\n");
@@ -459,7 +461,7 @@ public abstract class Dap4Responder extends BesDapResponder  {
 
 
 
-
+      */
 
 
 
@@ -548,7 +550,7 @@ public abstract class Dap4Responder extends BesDapResponder  {
     /**
      * If addTypeSuffixToDownloadFilename() is true, append the value of
      * getRequestSuffix() to the name.
-     * 
+     *
      * {@inheritDoc}
      */
     @Override
@@ -560,10 +562,10 @@ public abstract class Dap4Responder extends BesDapResponder  {
         // new rule: if addType...() is true, then look at 'name' and do one of the following:
         //              file.<ext>: remove '.<ext>' and append the value of getRequestSuffix()
         //              file [no ext at all]: append getRequestSuffix()
-        //           else if addType...() is not true, provide the old behavior 
+        //           else if addType...() is not true, provide the old behavior
         // Assume that all <ext> are no more than three characters long (some are, but this is
         // a reasonable compromise).
-        
+
         if(addTypeSuffixToDownloadFilename()) {
         	int dotPos = name.lastIndexOf('.');	// -1 if '.' not found
         	int extLength = name.length() - (dotPos + 1);
@@ -572,7 +574,7 @@ public abstract class Dap4Responder extends BesDapResponder  {
         		name = name.substring(0, dotPos);
         	}
         }
-        	
+
         name += getRequestSuffix();
 
         return name;

--- a/src/opendap/bes/dap4Responders/DataResponse/Netcdf3DR.java
+++ b/src/opendap/bes/dap4Responders/DataResponse/Netcdf3DR.java
@@ -112,7 +112,7 @@ public class Netcdf3DR extends Dap4Responder{
         QueryParameters qp = new QueryParameters(request);
 
         String resourceID = getResourceId(requestedResourceId, false);
-        String cf_history_entry = getCFHistoryEntry(request);
+        String cf_history_entry = ReqInfo.getCFHistoryEntry(request);
 
 
         BesApi besApi = getBesApi();

--- a/src/opendap/bes/dap4Responders/DataResponse/Netcdf4DR.java
+++ b/src/opendap/bes/dap4Responders/DataResponse/Netcdf4DR.java
@@ -112,7 +112,7 @@ public class Netcdf4DR extends Dap4Responder{
 
         QueryParameters qp = new QueryParameters(request);
         String resourceID = getResourceId(requestedResourceId, false);
-        String cf_history_entry = getCFHistoryEntry(request);
+        String cf_history_entry = ReqInfo.getCFHistoryEntry(request);
 
         BesApi besApi = getBesApi();
 

--- a/src/opendap/coreServlet/MimeTypes.java
+++ b/src/opendap/coreServlet/MimeTypes.java
@@ -203,6 +203,10 @@ public class MimeTypes {
         typeMap.put("dods",    new String[] {"application","octet-stream"});
         typeMap.put("xdods",   new String[] {"text","xml"});
 
+        typeMap.put("dap",     new String[] {"application", "vnd.opendap.dap4.data"});
+        typeMap.put("dmr",     new String[] {"application", "vnd.opendap.dap4.dataset-metadata+xml"});
+        typeMap.put("dsr",     new String[] {"application", "vnd.opendap.dap4.dataset-services+xml"});
+
 
         typeMap.put("jnlp",    new String[] {"application","x-java-jnlp-file"});
 

--- a/src/opendap/coreServlet/ReqInfo.java
+++ b/src/opendap/coreServlet/ReqInfo.java
@@ -34,8 +34,12 @@ import org.slf4j.Logger;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.text.FieldPosition;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Enumeration;
 import java.util.Map;
+import java.util.SimpleTimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
@@ -750,6 +754,53 @@ public class ReqInfo {
         return false;
 
     }
+
+    private static final String CF_History_Entry_Date_Format = "yyyy-MM-dd HH:mm:ss z";
+
+    public  static String getCFHistoryEntry(HttpServletRequest request) throws IOException {
+
+        StringBuilder cf_history_entry = new StringBuilder();
+
+        // Add the date
+        Date now = new Date();
+        SimpleDateFormat sdf = new SimpleDateFormat(CF_History_Entry_Date_Format);
+        sdf.setTimeZone(new SimpleTimeZone(0,"GMT"));
+        cf_history_entry.append(sdf.format(now,new StringBuffer(),new FieldPosition(0)));
+        cf_history_entry.append(" ");
+
+
+        // Add the Hyrax Version
+        cf_history_entry.append("Hyrax-").append(opendap.bes.Version.getHyraxVersionString());
+        cf_history_entry.append(" ");
+
+        // Add the complete request URL
+        cf_history_entry.append(getRequestUrlPath(request));
+        cf_history_entry.append("?");
+        cf_history_entry.append(ReqInfo.getConstraintExpression(request));
+        cf_history_entry.append("\n");
+
+        return cf_history_entry.toString();
+    }
+
+
+
+
+    public static String getRequestUrlPath(HttpServletRequest req) {
+        String forwardRequestUri = (String)req.getAttribute("javax.servlet.forward.request_uri");
+        String requestUrl = req.getRequestURL().toString();
+
+
+        if(forwardRequestUri != null){
+            String server = req.getServerName();
+            int port = req.getServerPort();
+            String scheme = req.getScheme();
+            requestUrl = scheme + "://" + server + ":" + port + forwardRequestUri;
+        }
+
+        return requestUrl;
+    }
+
+
 }                                                          
 
 

--- a/src/opendap/http/Util.java
+++ b/src/opendap/http/Util.java
@@ -1,3 +1,28 @@
+/*
+ * /////////////////////////////////////////////////////////////////////////////
+ * // This file is part of the "Hyrax Data Server" project.
+ * //
+ * //
+ * // Copyright (c) 2017 OPeNDAP, Inc.
+ * // Author: Nathan David Potter  <ndp@opendap.org>
+ * //
+ * // This library is free software; you can redistribute it and/or
+ * // modify it under the terms of the GNU Lesser General Public
+ * // License as published by the Free Software Foundation; either
+ * // version 2.1 of the License, or (at your option) any later version.
+ * //
+ * // This library is distributed in the hope that it will be useful,
+ * // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * // Lesser General Public License for more details.
+ * //
+ * // You should have received a copy of the GNU Lesser General Public
+ * // License along with this library; if not, write to the Free Software
+ * // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+ * //
+ * // You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+ * /////////////////////////////////////////////////////////////////////////////
+ */
 package opendap.http;
 
 import org.apache.http.Header;
@@ -27,8 +52,11 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 
-
 public class Util {
+
+    public static final String HTTP_PROTOCOL = "http://";
+    public static final String HTTPS_PROTOCOL = "https://";
+    public static final String BES_PROTOCOL = "bes://";
 
     static private Logger _log;
     static {

--- a/src/opendap/wcs/v2_0/DynamicCoverageDescription.java
+++ b/src/opendap/wcs/v2_0/DynamicCoverageDescription.java
@@ -119,14 +119,14 @@ public class DynamicCoverageDescription extends CoverageDescription {
         _log.debug("ingestDMR() - BEGIN");
 
         Dataset dataset = buildDataset(dmr);
-        _log.debug("Marshalling WCS from DMR at Url: {}", dataset.getUrl());
+        _log.debug("Building wcs:CoverageDescription from DMR at Url: {}", dataset.getUrl());
 
         CoverageDescriptionType cd = new CoverageDescriptionType();
         cd.setCoverageId(dataset.getName());
         cd.setId(dataset.getName());
 
         String datasetUrl = dmr.getAttributeValue("base", XML.NS);
-        setDapDatasetUrl(new URL(datasetUrl));
+        setDapDatasetUrl(datasetUrl);
 
         addServiceParameters(cd);
 

--- a/src/opendap/wcs/v2_0/DynamicServiceCatalog.java
+++ b/src/opendap/wcs/v2_0/DynamicServiceCatalog.java
@@ -27,6 +27,7 @@ package opendap.wcs.v2_0;
 
 import opendap.PathBuilder;
 import opendap.bes.BESError;
+import opendap.bes.BESManager;
 import opendap.bes.BadConfigurationException;
 import opendap.bes.dap2Responders.BesApi;
 import opendap.dap4.QueryParameters;
@@ -226,6 +227,9 @@ public class DynamicServiceCatalog implements WcsCatalog{
                 try {
                     if (datasetUrl.startsWith(Util.BES_PROTOCOL)) {
                         String besDatasource = datasetUrl.substring(Util.BES_PROTOCOL.length());
+                        if(!BESManager.isInitialized())
+                            throw new WcsException("The BESManager has not been configured. " +
+                                    "Unable to access BES!",WcsException.NO_APPLICABLE_CODE);
                         BesApi besApi = new BesApi();
                         QueryParameters qp = new QueryParameters();
                         try {

--- a/src/opendap/wcs/v2_0/DynamicServiceCatalog.java
+++ b/src/opendap/wcs/v2_0/DynamicServiceCatalog.java
@@ -352,12 +352,6 @@ public class DynamicServiceCatalog implements WcsCatalog{
         return new Vector<>();
     }
 
-    public String getDmrUrl(String coverageId) throws InterruptedException {
-        String datasetUrl =  getDataAccessUrl(coverageId);
-        if(datasetUrl==null)
-            return null;
-        return datasetUrl + ".dmr.xml";
-    }
 
 
     /**
@@ -399,7 +393,7 @@ public class DynamicServiceCatalog implements WcsCatalog{
         _log.debug("getDataAccessUrl() - DynamicService instance: {}",dynamicService);
         if(dynamicService==null)
             return null;
-        String resourceId = coverageId.replaceFirst(dynamicService.getName(),"");
+        String resourceId = coverageId.substring(dynamicService.getName().length());
         PathBuilder pb = new PathBuilder(dynamicService.getDapServiceUrlString().toString());
         pb.pathAppend(resourceId);
         pb.append("");

--- a/src/opendap/wcs/v2_0/DynamicServiceCatalog.java
+++ b/src/opendap/wcs/v2_0/DynamicServiceCatalog.java
@@ -197,7 +197,7 @@ public class DynamicServiceCatalog implements WcsCatalog{
 
         _log.debug("getCachedDMR() - BEGIN coverageId: {}",coverageId);
 
-        String datasetUrl = getDataAccessUrl(coverageId);
+        String datasetUrl = getDapDatsetUrl(coverageId);
         _log.debug("getCachedDMR() - DAP Dataset URL: {}",datasetUrl);
         if(datasetUrl==null)
             return null;
@@ -387,10 +387,10 @@ public class DynamicServiceCatalog implements WcsCatalog{
 
 
     @Override
-    public String getDataAccessUrl(String coverageId) throws InterruptedException {
-        _log.debug("getDataAccessUrl() - BEGIN coverageId: {}",coverageId);
+    public String getDapDatsetUrl(String coverageId) throws InterruptedException {
+        _log.debug("getDapDatsetUrl() - BEGIN coverageId: {}",coverageId);
         DynamicService dynamicService = getLongestMatchingDynamicService(coverageId);
-        _log.debug("getDataAccessUrl() - DynamicService instance: {}",dynamicService);
+        _log.debug("getDapDatsetUrl() - DynamicService instance: {}",dynamicService);
         if(dynamicService==null)
             return null;
         String resourceId = coverageId.substring(dynamicService.getName().length());

--- a/src/opendap/wcs/v2_0/GetCoverageRequest.java
+++ b/src/opendap/wcs/v2_0/GetCoverageRequest.java
@@ -53,6 +53,7 @@ public class GetCoverageRequest {
     private HashMap<String, DimensionSubset> _dimensionSubsets;
     private TemporalDimensionSubset _temporalSubset;
     private RangeSubset _rangeSubset;
+    private String _cfHistoryAttribute;
 
     private String _requestUrl;
 
@@ -73,7 +74,7 @@ public class GetCoverageRequest {
         _mediaType      = null;
         _dimensionSubsets = new HashMap<>();
         _requestUrl     = null;
-
+        _cfHistoryAttribute = null;
 
         _scaleRequest   = null;
         _rangeSubset    = null;
@@ -427,5 +428,12 @@ public class GetCoverageRequest {
     }
 
 
+    public void setCfHistoryAttribute(String s){
+        _cfHistoryAttribute = s;
+    }
+
+    public String getCfHistoryAttribute(){
+        return _cfHistoryAttribute;
+    }
 
 }

--- a/src/opendap/wcs/v2_0/GetCoverageRequestProcessor.java
+++ b/src/opendap/wcs/v2_0/GetCoverageRequestProcessor.java
@@ -27,6 +27,7 @@ package opendap.wcs.v2_0;
 
 
 import opendap.bes.BESError;
+import opendap.bes.BESManager;
 import opendap.bes.BadConfigurationException;
 import opendap.bes.dap2Responders.BesApi;
 import opendap.coreServlet.Scrub;
@@ -115,6 +116,10 @@ public class GetCoverageRequestProcessor {
             CoverageDescription coverageDescription = wcsCatalog.getCoverageDescription(coverageId);
             String besDatasetId = dapDatasetUrl.substring(Util.BES_PROTOCOL.length());
             Document besCmd = getBesCmd(req,coverageDescription,wcsCatalog);
+
+            if(!BESManager.isInitialized())
+                throw new WcsException("The BESManager has not been configured. Unable to access BES!",WcsException.NO_APPLICABLE_CODE);
+
             BesApi besApi = new BesApi();
             besApi.besTransaction(besDatasetId,besCmd,response.getOutputStream());
         }
@@ -663,7 +668,6 @@ public class GetCoverageRequestProcessor {
 
         Document besCmd = null;
         String dap2ce = GetCoverageRequestProcessor.getDap2CE(req);
-        opendap.bes.dap2Responders.BesApi besApi = new opendap.bes.dap2Responders.BesApi();
         String format = GetCoverageRequestProcessor.getReturnFormat(req);
         WcsResponseFormat rFormat = ServerCapabilities.getFormat(format);
 
@@ -671,6 +675,10 @@ public class GetCoverageRequestProcessor {
         String besUrl = wcsCatalog.getDapDatsetUrl(cd.getCoverageId());
         String besDatatsetId = besUrl.substring(Util.BES_PROTOCOL.length());
 
+        if(!BESManager.isInitialized())
+            throw new WcsException("The BESManager has not been configured. Unable to access BES!",WcsException.NO_APPLICABLE_CODE);
+
+        BesApi besApi = new BesApi();
         try {
 
             switch (rFormat.type()) {

--- a/src/opendap/wcs/v2_0/LfcMarshaller.java
+++ b/src/opendap/wcs/v2_0/LfcMarshaller.java
@@ -29,7 +29,7 @@ public class LfcMarshaller {
 		CoverageDescription cd = new CoverageDescription();
 		try
 		{
-		 cd.setDapDatasetUrl(new java.net.URL("http://localhost:8080/opendap/testbed-13/MERRA2_400.tavgM_2d_int_Nx.201601.nc4"));
+		 cd.setDapDatasetUrl("http://localhost:8080/opendap/testbed-13/MERRA2_400.tavgM_2d_int_Nx.201601.nc4");
 		}
 		catch (Exception e)
 		{
@@ -89,7 +89,7 @@ public class LfcMarshaller {
 		EOCoverageDescription ecd = new EOCoverageDescription();
 		try
 		{
-		 ecd.setDapDatasetUrl(new java.net.URL("http://localhost:8080/opendap/testbed-12/ncep/Global_0p25deg_best_hs002.nc"));
+		 ecd.setDapDatasetUrl("http://localhost:8080/opendap/testbed-12/ncep/Global_0p25deg_best_hs002.nc");
 		}
 		catch (Exception e)
 		{

--- a/src/opendap/wcs/v2_0/LocalFileCatalog.java
+++ b/src/opendap/wcs/v2_0/LocalFileCatalog.java
@@ -586,15 +586,10 @@ public class LocalFileCatalog implements WcsCatalog {
 
     @Override
     public String getDataAccessUrl(String coverageID) {
-
         CoverageDescription cd = _coveragesMap.get(coverageID);
-
         if (cd == null)
             return null;
-
-        URL dataAccessUrl = cd.getDapDatasetUrl();
-
-        return dataAccessUrl.toExternalForm();
+        return cd.getDapDatasetUrl();
     }
 
 

--- a/src/opendap/wcs/v2_0/LocalFileCatalog.java
+++ b/src/opendap/wcs/v2_0/LocalFileCatalog.java
@@ -585,7 +585,7 @@ public class LocalFileCatalog implements WcsCatalog {
     }
 
     @Override
-    public String getDataAccessUrl(String coverageID) {
+    public String getDapDatsetUrl(String coverageID) {
         CoverageDescription cd = _coveragesMap.get(coverageID);
         if (cd == null)
             return null;

--- a/src/opendap/wcs/v2_0/LocalFileCatalog.java
+++ b/src/opendap/wcs/v2_0/LocalFileCatalog.java
@@ -472,26 +472,21 @@ public class LocalFileCatalog implements WcsCatalog {
 
 
     public Element getCoverageSummaryElement(String id) throws WcsException {
-        return _coveragesMap.get(id).getCoverageSummary();
+        CoverageDescription cd = _coveragesMap.get(id);
+        return cd==null?null:cd.getCoverageSummary();
     }
 
     @Override
     public Collection<Element> getCoverageSummaryElements() throws WcsException {
 
-
         TreeMap<String, Element> coverageSummaries = new TreeMap<>();
-
         Enumeration e = _coveragesMap.elements();
-
         CoverageDescription cd;
-
+        
         while (e.hasMoreElements()) {
             cd = (CoverageDescription) e.nextElement();
-
             coverageSummaries.put(cd.getCoverageId(), cd.getCoverageSummary());
-
         }
-
         return coverageSummaries.values();
     }
 

--- a/src/opendap/wcs/v2_0/OgcDataEncoding.java
+++ b/src/opendap/wcs/v2_0/OgcDataEncoding.java
@@ -40,8 +40,21 @@ public class OgcDataEncoding {
     private static ConcurrentHashMap<String, String> ogcDataEncodings;
     static {
         ogcDataEncodings = new ConcurrentHashMap<String, String>();
-        ogcDataEncodings.put("application/x-netcdf","http://www.opengis.net/spec/WCS_coverage-encoding_netcdf/req/CF-netCDF");
-        ogcDataEncodings.put("application/octet-stream","http://www.opengis.net/spec/WCS_coverage-encoding_opendap/req/dap2");
+
+        ogcDataEncodings.put(
+                "application/x-netcdf","http://www.opengis.net/spec/WCS_coverage-encoding_netcdf/req/CF-netCDF");
+
+        ogcDataEncodings.put(
+                "application/octet-stream","http://www.opengis.net/spec/WCS_coverage-encoding_opendap/req/dap2");
+
+        ogcDataEncodings.put(
+                "application/vnd.opendap.dap4.data","http://www.opengis.net/spec/WCS_coverage-encoding_opendap/req/dap4");
+
+        ogcDataEncodings.put(
+                "image/tiff","http://www.opengis.net/spec/WCS_coverage-encoding_opendap/req/geotiff");
+
+        ogcDataEncodings.put(
+                "image/jp2","http://www.opengis.net/spec/WCS_coverage-encoding_opendap/req/gml-jpeg2000");
     }
 
     public static String getEncodingUri(String mimeType){

--- a/src/opendap/wcs/v2_0/ServerCapabilities.java
+++ b/src/opendap/wcs/v2_0/ServerCapabilities.java
@@ -52,7 +52,7 @@ public class ServerCapabilities {
         rf = new GeotiffFormat();
         _responseFormats.put(rf.name(),rf);
 
-        rf = new Jpeg200Format();
+        rf = new Jpeg2000Format();
         _responseFormats.put(rf.name(),rf);
 
         rf = new Dap2DataFormat();

--- a/src/opendap/wcs/v2_0/WcsCatalog.java
+++ b/src/opendap/wcs/v2_0/WcsCatalog.java
@@ -261,7 +261,7 @@ public interface WcsCatalog {
      * @return  The base data access URL for this coverage. Null otherwise.
      * @throws InterruptedException
      */
-    public String getDataAccessUrl(String coverageID) throws InterruptedException;
+    public String getDapDatsetUrl(String coverageID) throws InterruptedException;
 
 
 

--- a/src/opendap/wcs/v2_0/formats/Dap2DataFormat.java
+++ b/src/opendap/wcs/v2_0/formats/Dap2DataFormat.java
@@ -33,5 +33,6 @@ public class Dap2DataFormat extends WcsResponseFormat {
         _name = "dap2";
         _dapSuffix = "dods";
         _mimeType = MimeTypes.getMimeType(_dapSuffix);
+        _type = Type.dap2;
     }
 }

--- a/src/opendap/wcs/v2_0/formats/Dap4DataFormat.java
+++ b/src/opendap/wcs/v2_0/formats/Dap4DataFormat.java
@@ -33,5 +33,6 @@ public class Dap4DataFormat extends WcsResponseFormat {
         _name = "dap4";
         _dapSuffix = "dap";
         _mimeType = MimeTypes.getMimeType(_dapSuffix);
+        _type = Type.dap4;
     }
 }

--- a/src/opendap/wcs/v2_0/formats/GeotiffFormat.java
+++ b/src/opendap/wcs/v2_0/formats/GeotiffFormat.java
@@ -33,5 +33,6 @@ public class GeotiffFormat extends WcsResponseFormat {
         _name = "geotiff";
         _dapSuffix = "tiff";
         _mimeType = MimeTypes.getMimeType(_dapSuffix);
+        _type = Type.geotiff;
     }
 }

--- a/src/opendap/wcs/v2_0/formats/Jpeg2000Format.java
+++ b/src/opendap/wcs/v2_0/formats/Jpeg2000Format.java
@@ -27,12 +27,12 @@ package opendap.wcs.v2_0.formats;
 
 import opendap.coreServlet.MimeTypes;
 
-public class Jpeg200Format extends WcsResponseFormat {
-    public Jpeg200Format(){
+public class Jpeg2000Format extends WcsResponseFormat {
+    public Jpeg2000Format(){
         super();
         _name = "jpeg2000";
         _dapSuffix = "jp2";
         _mimeType = MimeTypes.getMimeType(_dapSuffix);
-
+        _type = Type.jpeg2000;
     }
 }

--- a/src/opendap/wcs/v2_0/formats/NetCdfFormat.java
+++ b/src/opendap/wcs/v2_0/formats/NetCdfFormat.java
@@ -33,5 +33,6 @@ public class NetCdfFormat extends WcsResponseFormat {
         _name = "netcdf";
         _dapSuffix = "nc";
         _mimeType = MimeTypes.getMimeType(_dapSuffix);
+        _type = Type.netcdf;
     }
 };

--- a/src/opendap/wcs/v2_0/formats/WcsResponseFormat.java
+++ b/src/opendap/wcs/v2_0/formats/WcsResponseFormat.java
@@ -26,6 +26,10 @@
 package opendap.wcs.v2_0.formats;
 
 public class WcsResponseFormat {
+    public enum Type {
+        dap2, dap4, geotiff, jpeg2000, netcdf
+    }
+    protected Type _type;
     protected String _name;
     protected String _mimeType;
     protected String _dapSuffix;
@@ -33,8 +37,10 @@ public class WcsResponseFormat {
         _name = null;
         _mimeType = null;
         _dapSuffix = null;
+        _type = null;
     }
     public String dapDataResponseSuffix(){ return _dapSuffix.toLowerCase();};
     public String name(){ return _name.toLowerCase(); }
     public String mimeType(){return _mimeType.toLowerCase();}
+    public Type type(){return  _type;}
 }

--- a/src/opendap/wcs/v2_0/http/Attachment.java
+++ b/src/opendap/wcs/v2_0/http/Attachment.java
@@ -26,6 +26,7 @@
 package opendap.wcs.v2_0.http;
 
 import opendap.bes.BESError;
+import opendap.bes.BESManager;
 import opendap.bes.BadConfigurationException;
 import opendap.bes.dap2Responders.BesApi;
 import opendap.ppt.PPTException;
@@ -203,8 +204,12 @@ public class Attachment {
                 break;
 
             case bes:
+                if(!BESManager.isInitialized()) {
+                    throw new BadConfigurationException("The BESManager has not been configured. " +
+                            "Unable to access BES!");
+                }
                 BesApi besApi = new BesApi();
-                besApi.besTransaction(_besDatasetId,_besCmd,sos);
+                besApi.besTransaction(_besDatasetId, _besCmd, sos);
                 break;
 
             case document:

--- a/src/opendap/wcs/v2_0/http/KvpHandler.java
+++ b/src/opendap/wcs/v2_0/http/KvpHandler.java
@@ -25,6 +25,8 @@
  */
 package opendap.wcs.v2_0.http;
 
+import opendap.PathBuilder;
+import opendap.coreServlet.ReqInfo;
 import opendap.wcs.v2_0.*;
 import org.jdom.Document;
 import org.jdom.output.Format;
@@ -32,8 +34,10 @@ import org.jdom.output.XMLOutputter;
 import org.slf4j.Logger;
 
 import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -63,18 +67,21 @@ public class KvpHandler {
 
     }
 
-    public static void processKvpWcsRequest(String serviceURL, String requestUrl, Map<String,String[]> keyValuePairs, HttpServletResponse response) throws InterruptedException, IOException {
+    public static void processKvpWcsRequest(HttpServletRequest request, HttpServletResponse response) throws InterruptedException, IOException {
+        Map<String,String[]> keyValuePairs  =  getKVP(request);
         Document wcsResponse;
         ServletOutputStream os  = null;
         try {
             os  = response.getOutputStream();
-
             WCS.REQUEST wcsRequestType = getRequestType(keyValuePairs);
 
             switch(wcsRequestType){
 
                 case GET_CAPABILITIES:
-                    wcsResponse = getCapabilities(keyValuePairs, serviceURL);
+                    String baseServiceUrl = Util.getServiceUrl(request);
+                    String relativeURL = ReqInfo.getLocalUrl(request);
+                    String wcsServiceUrl = PathBuilder.pathConcat(baseServiceUrl,relativeURL);
+                    wcsResponse = getCapabilities(keyValuePairs, wcsServiceUrl);
                     response.setContentType("text/xml");
                     transmitXML(wcsResponse,os);
                     break;
@@ -93,7 +100,7 @@ public class KvpHandler {
 
                 case GET_COVERAGE:
 
-                    getCoverage(requestUrl, keyValuePairs,response);
+                    getCoverage(request, keyValuePairs, response);
 
                     break;
 
@@ -173,10 +180,12 @@ public class KvpHandler {
      * @throws InterruptedException
      * @throws IOException
      */
-    public static void getCoverage(String requestUrl, Map<String, String[]> keyValuePairs, HttpServletResponse response) throws InterruptedException, WcsException, IOException {
+    public static void getCoverage(HttpServletRequest request, Map<String, String[]> keyValuePairs, HttpServletResponse response) throws InterruptedException, WcsException, IOException {
 
+        String requestUrl = HttpGetHandler.getRequestUrlWithQuery(request);
         GetCoverageRequest req = new GetCoverageRequest(requestUrl, keyValuePairs);
 
+        req.setCfHistoryAttribute(ReqInfo.getCFHistoryEntry(request));
         GetCoverageRequestProcessor.sendCoverageResponse(req, response, false );
 
     }
@@ -227,6 +236,44 @@ public class KvpHandler {
 
 
     }
+
+
+    public static Map<String, String[]> getKVP(HttpServletRequest request){
+        Map<String,String[]> requestParameters = new HashMap<>();
+        Map pmap =  request.getParameterMap();
+
+        for(Object o: pmap.keySet()){
+            String key = (String) o;   // Get the key String
+            String[] value = (String[]) pmap.get(key);  // Get the value before we change the key
+            key = key.toLowerCase(); // Make the key set case insensitive;
+            requestParameters.put(key,value);
+        }
+
+
+        String localUrl = ReqInfo.getLocalUrl(request);
+        while(localUrl.startsWith("/") && !localUrl.isEmpty()){
+            localUrl = localUrl.substring(1,localUrl.length());
+        }
+        while(localUrl.endsWith("/") && !localUrl.isEmpty()){
+            localUrl = localUrl.substring(0,localUrl.length()-1);
+        }
+        if( localUrl!=null &&
+                !localUrl.isEmpty() &&
+                !requestParameters.containsKey("coverageId".toLowerCase())){
+
+            String[] vals;
+            vals = new String[1];
+            vals[0] = localUrl;
+            requestParameters.put("coverageId".toLowerCase(), vals);
+        }
+
+
+        return requestParameters;
+
+    }
+
+
+
 
 
 }

--- a/src/opendap/wcs/v2_0/http/KvpHandler.java
+++ b/src/opendap/wcs/v2_0/http/KvpHandler.java
@@ -26,7 +26,10 @@
 package opendap.wcs.v2_0.http;
 
 import opendap.PathBuilder;
+import opendap.bes.BESError;
+import opendap.bes.BadConfigurationException;
 import opendap.coreServlet.ReqInfo;
+import opendap.ppt.PPTException;
 import opendap.wcs.v2_0.*;
 import org.jdom.Document;
 import org.jdom.output.Format;
@@ -67,7 +70,7 @@ public class KvpHandler {
 
     }
 
-    public static void processKvpWcsRequest(HttpServletRequest request, HttpServletResponse response) throws InterruptedException, IOException {
+    public static void processKvpWcsRequest(HttpServletRequest request, HttpServletResponse response) throws InterruptedException, IOException, PPTException, BadConfigurationException, BESError {
         Map<String,String[]> keyValuePairs  =  getKVP(request);
         Document wcsResponse;
         ServletOutputStream os  = null;
@@ -180,7 +183,7 @@ public class KvpHandler {
      * @throws InterruptedException
      * @throws IOException
      */
-    public static void getCoverage(HttpServletRequest request, Map<String, String[]> keyValuePairs, HttpServletResponse response) throws InterruptedException, WcsException, IOException {
+    public static void getCoverage(HttpServletRequest request, Map<String, String[]> keyValuePairs, HttpServletResponse response) throws InterruptedException, WcsException, IOException, PPTException, BadConfigurationException, BESError {
 
         String requestUrl = HttpGetHandler.getRequestUrlWithQuery(request);
         GetCoverageRequest req = new GetCoverageRequest(requestUrl, keyValuePairs);

--- a/src/opendap/wcs/v2_0/http/MultipartResponse.java
+++ b/src/opendap/wcs/v2_0/http/MultipartResponse.java
@@ -25,6 +25,9 @@
  */
 package opendap.wcs.v2_0.http;
 
+import opendap.bes.BESError;
+import opendap.bes.BadConfigurationException;
+import opendap.ppt.PPTException;
 import org.jdom.output.Format;
 import org.jdom.output.XMLOutputter;
 import org.slf4j.Logger;
@@ -119,7 +122,7 @@ public class MultipartResponse {
      *
      * @throws java.io.IOException When things go wrong
      */
-    public void send(HttpServletResponse servResponse) throws IOException, URISyntaxException {
+    public void send(HttpServletResponse servResponse) throws IOException, URISyntaxException, PPTException, BadConfigurationException, BESError {
         log.debug("Sending Response...");
 
         log.debug("MIME Boundary: " + mimeBoundary);

--- a/src/opendap/wcs/v2_0/http/Servlet.java
+++ b/src/opendap/wcs/v2_0/http/Servlet.java
@@ -163,15 +163,16 @@ public class Servlet extends HttpServlet {
         } catch (IOException | JDOMException e) {
             String msg = "Unable to read BES configuration file. Caught " + e.getClass().getSimpleName() +
                     " message: " + e.getMessage();
-            _log.error(msg);
-            throw new ServletException(msg);
+            _log.warn(msg);
+            // throw new ServletException(msg);
+            return;
         }
         Element besManagerElement = config.getChild("BESManager");
 
         if (besManagerElement == null) {
             String msg = "Invalid configuration. Missing required 'BESManager' element. DispatchServlet FAILED to init()!";
-            _log.error(msg);
-            throw new ServletException(msg);
+            _log.warn(msg);
+            return;
         }
 
         BESManager besManager  = new BESManager();
@@ -179,6 +180,8 @@ public class Servlet extends HttpServlet {
             try {
                 besManager.init(besManagerElement);
             } catch (Exception e) {
+                String msg = "BES initialization was an abject failure ";
+
                 throw new ServletException(e);
             }
         }

--- a/src/opendap/wcs/v2_0/http/Servlet.java
+++ b/src/opendap/wcs/v2_0/http/Servlet.java
@@ -163,15 +163,14 @@ public class Servlet extends HttpServlet {
         } catch (IOException | JDOMException e) {
             String msg = "Unable to read BES configuration file. Caught " + e.getClass().getSimpleName() +
                     " message: " + e.getMessage();
-            _log.warn(msg);
-            // throw new ServletException(msg);
+            _log.error(msg);
             return;
         }
         Element besManagerElement = config.getChild("BESManager");
 
         if (besManagerElement == null) {
-            String msg = "Invalid configuration. Missing required 'BESManager' element. DispatchServlet FAILED to init()!";
-            _log.warn(msg);
+            String msg = "Invalid BES configuration. Missing required 'BESManager' element. BES was not initialized!";
+            _log.error(msg);
             return;
         }
 
@@ -180,9 +179,9 @@ public class Servlet extends HttpServlet {
             try {
                 besManager.init(besManagerElement);
             } catch (Exception e) {
-                String msg = "BES initialization was an abject failure ";
-
-                throw new ServletException(e);
+                String msg = "BESManager initialization was an abject failure. BES was not initialized! " +
+                        "Caught "+e.getClass().getName()+ " message: "+e.getMessage();
+                _log.error(msg);
             }
         }
 

--- a/src/opendap/wcs/v2_0/http/SoapHandler.java
+++ b/src/opendap/wcs/v2_0/http/SoapHandler.java
@@ -25,9 +25,12 @@
  */
 package opendap.wcs.v2_0.http;
 
+import opendap.bes.BESError;
+import opendap.bes.BadConfigurationException;
 import opendap.coreServlet.DispatchServlet;
 import opendap.namespaces.NS;
 import opendap.namespaces.SOAP;
+import opendap.ppt.PPTException;
 import opendap.wcs.v2_0.*;
 import org.jdom.Document;
 import org.jdom.Element;
@@ -117,7 +120,7 @@ public class SoapHandler extends XmlRequestHandler {
 
 
     @Override
-    public void sendCoverageResponse(GetCoverageRequest req, HttpServletResponse response) throws InterruptedException, WcsException, IOException {
+    public void sendCoverageResponse(GetCoverageRequest req, HttpServletResponse response) throws InterruptedException, WcsException, IOException, PPTException, BadConfigurationException, BESError {
 
         GetCoverageRequestProcessor.sendCoverageResponse(req, response, true );
 

--- a/src/opendap/wcs/v2_0/http/XmlRequestHandler.java
+++ b/src/opendap/wcs/v2_0/http/XmlRequestHandler.java
@@ -26,7 +26,10 @@
 package opendap.wcs.v2_0.http;
 
 import opendap.PathBuilder;
+import opendap.bes.BESError;
+import opendap.bes.BadConfigurationException;
 import opendap.coreServlet.ReqInfo;
+import opendap.ppt.PPTException;
 import opendap.wcs.v2_0.*;
 import org.jdom.Document;
 import org.jdom.Element;
@@ -330,7 +333,7 @@ public class XmlRequestHandler implements opendap.coreServlet.DispatchHandler, W
      * @throws WcsException  When bad things happen.
      * @throws InterruptedException When it gets interrupted.
      */
-    public void sendCoverageResponse(GetCoverageRequest req, HttpServletResponse response) throws InterruptedException, WcsException, IOException {
+    public void sendCoverageResponse(GetCoverageRequest req, HttpServletResponse response) throws InterruptedException, WcsException, IOException, PPTException, BadConfigurationException, BESError {
 
         GetCoverageRequestProcessor.sendCoverageResponse(req, response, false );
 

--- a/src/opendap/wcs/v2_0/http/XmlRequestHandler.java
+++ b/src/opendap/wcs/v2_0/http/XmlRequestHandler.java
@@ -161,7 +161,7 @@ public class XmlRequestHandler implements opendap.coreServlet.DispatchHandler, W
         Element wcsRequest = wcsRequestDoc.getRootElement();
         String serviceUrl = PathBuilder.pathConcat(Util.getServiceUrl(request),_prefix);
 
-        String requestUrl=HttpGetHandler.getRequestUrl(request);
+        String requestUrl=HttpGetHandler.getRequestUrlWithQuery(request);
 
         handleWcsRequest(wcsRequest,serviceUrl,requestUrl, response);
 


### PR DESCRIPTION
Added BES support to WCS service. 

- The WCS service can run as it's own server and if it detects that the BESManager has not been initialized it will try to do so using the default file (olfs.xml).
- The WCS can run as a child servlet to the OLFS cluster.

```xml
<DynamicService name="lds" href="bes://" srs="urn:ogc:def:crs:EPSG::4326" >
    <DomainCoordinate name="time" dapID="time" size="1" units="Days since 1900-01-01T00:00:00.000Z" min="690" max="690"/>
    <DomainCoordinate name="latitude" dapID="lat" size="361" units="deg" min="-90" max="90"/>
    <DomainCoordinate name="longitude" dapID="lon" size="576" units="deg" min="-180" max="180"/>
</DynamicService>
```
In both cases when a DynamicService is configured using an _href_ attribute whose value starts with the protocol string "_bes://_" the service will talk directly with the BES system to fulfill requests. If the _href_ attribute value begins with either "http://" or "https://" then the service will utilize HTTP (authenticating as needed) to get DAP requests fulfilled but the referenced host.