### PR TITLE
Upgraded tests to work with Tomcat 8.5.x

### DIFF
--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.ascii
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.ascii
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?DODS_URL&date_time("1998/160:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.ascii
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.ascii
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?DODS_URL&date_time("1998/160:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.ascii
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.ascii
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?DODS_URL&date_time("1998/160:17:45:00")
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.das
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.das
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?DODS_URL&date_time("1998/160:17:45:00")
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.das
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.das
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?DODS_URL&date_time("1998/160:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.das
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.das
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?DODS_URL&date_time("1998/160:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.dds
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.dds
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?DODS_URL&date_time("1998/160:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.dds
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.dds
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?DODS_URL&date_time("1998/160:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.dds
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.dds
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?DODS_URL&date_time("1998/160:17:45:00")
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.dods
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.dods
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?DODS_URL&date_time("1998/160:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.dods
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.dods
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?DODS_URL&date_time("1998/160:17:45:00")
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.dods
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.dods
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?DODS_URL&date_time("1998/160:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.html
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.html
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?DODS_URL&date_time("1998/160:17:45:00")
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.html
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.html
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?DODS_URL&date_time("1998/160:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.html
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.html
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?DODS_URL&date_time("1998/160:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.info
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.info
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?DODS_URL&date_time("1998/160:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.info
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.info
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?DODS_URL&date_time("1998/160:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.info
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.info
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?DODS_URL&date_time("1998/160:17:45:00")
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.ascii
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.ascii
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?DODS_URL&date_time("1998/160:17:45:00","1998/165:17:45:00")
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%2C%221998%2F165%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.ascii
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.ascii
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?DODS_URL&date_time("1998/160:17:45:00","1998/165:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%2C%221998%2F165%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.ascii
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.ascii
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?DODS_URL&date_time("1998/160:17:45:00","1998/165:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%2C%221998%2F165%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.das
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.das
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?DODS_URL&date_time("1998/160:17:45:00","1998/165:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%2C%221998%2F165%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.das
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.das
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?DODS_URL&date_time("1998/160:17:45:00","1998/165:17:45:00")
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%2C%221998%2F165%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.das
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.das
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?DODS_URL&date_time("1998/160:17:45:00","1998/165:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%2C%221998%2F165%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.dds
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.dds
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?DODS_URL&date_time("1998/160:17:45:00","1998/165:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%2C%221998%2F165%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.dds
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.dds
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?DODS_URL&date_time("1998/160:17:45:00","1998/165:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%2C%221998%2F165%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.dds
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.dds
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?DODS_URL&date_time("1998/160:17:45:00","1998/165:17:45:00")
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%2C%221998%2F165%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.dods
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.dods
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?DODS_URL&date_time("1998/160:17:45:00","1998/165:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%2C%221998%2F165%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.dods
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.dods
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?DODS_URL&date_time("1998/160:17:45:00","1998/165:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%2C%221998%2F165%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.dods
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.dods
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?DODS_URL&date_time("1998/160:17:45:00","1998/165:17:45:00")
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%2C%221998%2F165%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.html
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.html
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?DODS_URL&date_time("1998/160:17:45:00","1998/165:17:45:00")
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%2C%221998%2F165%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.html
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.html
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?DODS_URL&date_time("1998/160:17:45:00","1998/165:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%2C%221998%2F165%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.html
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.html
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?DODS_URL&date_time("1998/160:17:45:00","1998/165:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%2C%221998%2F165%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.info
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.info
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?DODS_URL&date_time("1998/160:17:45:00","1998/165:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%2C%221998%2F165%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.info
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.info
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?DODS_URL&date_time("1998/160:17:45:00","1998/165:17:45:00")
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%2C%221998%2F165%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.info
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeRange_01.info
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?DODS_URL&date_time("1998/160:17:45:00","1998/165:17:45:00")
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?DODS_URL%26date_time%28%221998%2F160%3A17%3A45%3A00%22%2C%221998%2F165%3A17%3A45%3A00%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.ascii
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.ascii
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.ascii?geogrid(SST,61,-82,38,-19,"TIME<1500")
 url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.ascii?geogrid%28SST%2C61%2C-82%2C38%2C-19%2C%22TIME%3C1500%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.ascii
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.ascii
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.ascii?geogrid(SST,61,-82,38,-19,"TIME<1500")
+url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.ascii?geogrid%28SST%2C61%2C-82%2C38%2C-19%2C%22TIME%3C1500%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.ascii
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.ascii
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.ascii?geogrid(SST,61,-82,38,-19,"TIME<1500")
 url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.ascii?geogrid%28SST%2C61%2C-82%2C38%2C-19%2C%22TIME%3C1500%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.das
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.das
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.das?geogrid(SST,61,-82,38,-19,"TIME<1500")
 url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.das?geogrid%28SST%2C61%2C-82%2C38%2C-19%2C%22TIME%3C1500%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.das
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.das
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.das?geogrid(SST,61,-82,38,-19,"TIME<1500")
+url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.das?geogrid%28SST%2C61%2C-82%2C38%2C-19%2C%22TIME%3C1500%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.das
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.das
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.das?geogrid(SST,61,-82,38,-19,"TIME<1500")
 url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.das?geogrid%28SST%2C61%2C-82%2C38%2C-19%2C%22TIME%3C1500%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.dds
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.dds
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.dds?geogrid(SST,61,-82,38,-19,"TIME<1500")
 url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.dds?geogrid%28SST%2C61%2C-82%2C38%2C-19%2C%22TIME%3C1500%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.dds
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.dds
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.dds?geogrid(SST,61,-82,38,-19,"TIME<1500")
+url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.dds?geogrid%28SST%2C61%2C-82%2C38%2C-19%2C%22TIME%3C1500%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.dds
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.dds
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.dds?geogrid(SST,61,-82,38,-19,"TIME<1500")
 url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.dds?geogrid%28SST%2C61%2C-82%2C38%2C-19%2C%22TIME%3C1500%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.dods
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.dods
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.dods?geogrid(SST,61,-82,38,-19,"TIME<1500")
+url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.dods?geogrid%28SST%2C61%2C-82%2C38%2C-19%2C%22TIME%3C1500%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.dods
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.dods
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.dods?geogrid(SST,61,-82,38,-19,"TIME<1500")
 url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.dods?geogrid%28SST%2C61%2C-82%2C38%2C-19%2C%22TIME%3C1500%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.dods
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.dods
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.dods?geogrid(SST,61,-82,38,-19,"TIME<1500")
 url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.dods?geogrid%28SST%2C61%2C-82%2C38%2C-19%2C%22TIME%3C1500%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.html
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.html
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.html?geogrid(SST,61,-82,38,-19,"TIME<1500")
+url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.html?geogrid%28SST%2C61%2C-82%2C38%2C-19%2C%22TIME%3C1500%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.html
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.html
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.html?geogrid(SST,61,-82,38,-19,"TIME<1500")
 url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.html?geogrid%28SST%2C61%2C-82%2C38%2C-19%2C%22TIME%3C1500%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.html
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.html
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.html?geogrid(SST,61,-82,38,-19,"TIME<1500")
 url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.html?geogrid%28SST%2C61%2C-82%2C38%2C-19%2C%22TIME%3C1500%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.info
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.info
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.info?geogrid(SST,61,-82,38,-19,"TIME<1500")
+url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.info?geogrid%28SST%2C61%2C-82%2C38%2C-19%2C%22TIME%3C1500%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.info
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.info
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.info?geogrid(SST,61,-82,38,-19,"TIME<1500")
 url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.info?geogrid%28SST%2C61%2C-82%2C38%2C-19%2C%22TIME%3C1500%22%29
 -s

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.info
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.info
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.info?geogrid(SST,61,-82,38,-19,"TIME<1500")
 url = http://localhost:8080/opendap/data/nc/coads_climatology.nc.info?geogrid%28SST%2C61%2C-82%2C38%2C-19%2C%22TIME%3C1500%22%29
 -s

--- a/hyrax_tests/errors/BadConstraintSyntax.ascii.baseline.http_header
+++ b/hyrax_tests/errors/BadConstraintSyntax.ascii.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/BadConstraintSyntax.dap.baseline.http_header
+++ b/hyrax_tests/errors/BadConstraintSyntax.dap.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/BadConstraintSyntax.dap.csv.baseline.http_header
+++ b/hyrax_tests/errors/BadConstraintSyntax.dap.csv.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/BadConstraintSyntax.dds.baseline.http_header
+++ b/hyrax_tests/errors/BadConstraintSyntax.dds.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/BadConstraintSyntax.dmr.baseline.http_header
+++ b/hyrax_tests/errors/BadConstraintSyntax.dmr.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/BadConstraintSyntax.dmr.html.baseline.http_header
+++ b/hyrax_tests/errors/BadConstraintSyntax.dmr.html.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/BadConstraintSyntax.dods.baseline.http_header
+++ b/hyrax_tests/errors/BadConstraintSyntax.dods.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/BadConstraintSyntax.json.baseline.http_header
+++ b/hyrax_tests/errors/BadConstraintSyntax.json.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/IncompatibleMediaType.w10n.baseline.http_header
+++ b/hyrax_tests/errors/IncompatibleMediaType.w10n.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 406 Not Acceptable
+^HTTP/1\.1 406

--- a/hyrax_tests/errors/NoSuchVariable.ascii.baseline.http_header
+++ b/hyrax_tests/errors/NoSuchVariable.ascii.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/NoSuchVariable.dap.baseline.http_header
+++ b/hyrax_tests/errors/NoSuchVariable.dap.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/NoSuchVariable.dap.csv.baseline.http_header
+++ b/hyrax_tests/errors/NoSuchVariable.dap.csv.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/NoSuchVariable.dds.baseline.http_header
+++ b/hyrax_tests/errors/NoSuchVariable.dds.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/NoSuchVariable.dmr.baseline.http_header
+++ b/hyrax_tests/errors/NoSuchVariable.dmr.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/NoSuchVariable.dmr.html.baseline.http_header
+++ b/hyrax_tests/errors/NoSuchVariable.dmr.html.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/NoSuchVariable.dods.baseline.http_header
+++ b/hyrax_tests/errors/NoSuchVariable.dods.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/NoSuchVariable.json.baseline.http_header
+++ b/hyrax_tests/errors/NoSuchVariable.json.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/NoSuchVariable.w10n.baseline.http_header
+++ b/hyrax_tests/errors/NoSuchVariable.w10n.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/bes_forbidden_error.ascii.baseline.http_header
+++ b/hyrax_tests/errors/bes_forbidden_error.ascii.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 403 Forbidden
+^HTTP/1\.1 403

--- a/hyrax_tests/errors/bes_forbidden_error.dds.baseline.http_header
+++ b/hyrax_tests/errors/bes_forbidden_error.dds.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 403 Forbidden
+^HTTP/1\.1 403

--- a/hyrax_tests/errors/bes_forbidden_error.dods.baseline.http_header
+++ b/hyrax_tests/errors/bes_forbidden_error.dods.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 403 Forbidden
+^HTTP/1\.1 403

--- a/hyrax_tests/errors/bes_forbidden_error.json.baseline.http_header
+++ b/hyrax_tests/errors/bes_forbidden_error.json.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 403 Forbidden
+^HTTP/1\.1 403

--- a/hyrax_tests/errors/bes_internal_error.ascii.baseline.http_header
+++ b/hyrax_tests/errors/bes_internal_error.ascii.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 500 Internal Server Error
+^HTTP/1\.1 500

--- a/hyrax_tests/errors/bes_internal_error.dds.baseline.http_header
+++ b/hyrax_tests/errors/bes_internal_error.dds.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 500 Internal Server Error
+^HTTP/1\.1 500

--- a/hyrax_tests/errors/bes_internal_error.dods.baseline.http_header
+++ b/hyrax_tests/errors/bes_internal_error.dods.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 500 Internal Server Error
+^HTTP/1\.1 500

--- a/hyrax_tests/errors/bes_internal_error.json.baseline.http_header
+++ b/hyrax_tests/errors/bes_internal_error.json.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 500 Internal Server Error
+^HTTP/1\.1 500

--- a/hyrax_tests/errors/bes_internal_fatal_error.ascii.baseline.http_header
+++ b/hyrax_tests/errors/bes_internal_fatal_error.ascii.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 500 Internal Server Error
+^HTTP/1\.1 500

--- a/hyrax_tests/errors/bes_internal_fatal_error.dds.baseline.http_header
+++ b/hyrax_tests/errors/bes_internal_fatal_error.dds.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 500 Internal Server Error
+^HTTP/1\.1 500

--- a/hyrax_tests/errors/bes_internal_fatal_error.dods.baseline.http_header
+++ b/hyrax_tests/errors/bes_internal_fatal_error.dods.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 500 Internal Server Error
+^HTTP/1\.1 500

--- a/hyrax_tests/errors/bes_internal_fatal_error.json.baseline.http_header
+++ b/hyrax_tests/errors/bes_internal_fatal_error.json.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 500 Internal Server Error
+^HTTP/1\.1 500

--- a/hyrax_tests/errors/bes_not_found_error.ascii.baseline.http_header
+++ b/hyrax_tests/errors/bes_not_found_error.ascii.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 404 Not Found
+^HTTP/1\.1 404

--- a/hyrax_tests/errors/bes_not_found_error.dds.baseline.http_header
+++ b/hyrax_tests/errors/bes_not_found_error.dds.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 404 Not Found
+^HTTP/1\.1

--- a/hyrax_tests/errors/bes_not_found_error.dods.baseline.http_header
+++ b/hyrax_tests/errors/bes_not_found_error.dods.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 404 Not Found
+^HTTP/1\.1 404

--- a/hyrax_tests/errors/bes_not_found_error.json.baseline.http_header
+++ b/hyrax_tests/errors/bes_not_found_error.json.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 404 Not Found
+^HTTP/1\.1 404

--- a/hyrax_tests/errors/bes_syntax_user_error.ascii.baseline.http_header
+++ b/hyrax_tests/errors/bes_syntax_user_error.ascii.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/bes_syntax_user_error.dds.baseline.http_header
+++ b/hyrax_tests/errors/bes_syntax_user_error.dds.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/bes_syntax_user_error.dods.baseline.http_header
+++ b/hyrax_tests/errors/bes_syntax_user_error.dods.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/bes_syntax_user_error.json.baseline.http_header
+++ b/hyrax_tests/errors/bes_syntax_user_error.json.baseline.http_header
@@ -1,1 +1,1 @@
-^HTTP/1\.1 400 Bad Request
+^HTTP/1\.1 400

--- a/hyrax_tests/errors/bes_timeout_error.ascii.baseline.http_header
+++ b/hyrax_tests/errors/bes_timeout_error.ascii.baseline.http_header
@@ -1,7 +1,1 @@
-HTTP/1.1 504 Gateway Timeout
-Server: Apache-Coyote/1.1
-Content-Description: DAP2 Error Object
-Content-Type: text/plain
-Transfer-Encoding: chunked
-Date: Tue, 16 May 2017 21:21:16 GMT
-
+HTTP/1.1 504

--- a/hyrax_tests/errors/bes_timeout_error.dds.baseline.http_header
+++ b/hyrax_tests/errors/bes_timeout_error.dds.baseline.http_header
@@ -1,7 +1,1 @@
-HTTP/1.1 504 Gateway Timeout
-Server: Apache-Coyote/1.1
-Content-Description: DAP2 Error Object
-Content-Type: text/plain
-Transfer-Encoding: chunked
-Date: Tue, 16 May 2017 21:20:46 GMT
-
+HTTP/1.1 504

--- a/hyrax_tests/errors/bes_timeout_error.dods.baseline.http_header
+++ b/hyrax_tests/errors/bes_timeout_error.dods.baseline.http_header
@@ -1,7 +1,1 @@
-HTTP/1.1 504 Gateway Timeout
-Server: Apache-Coyote/1.1
-Content-Description: DAP2 Error Object
-Content-Type: text/plain
-Transfer-Encoding: chunked
-Date: Tue, 16 May 2017 21:21:44 GMT
-
+HTTP/1.1 504

--- a/hyrax_tests/errors/bes_timeout_error.json.baseline.http_header
+++ b/hyrax_tests/errors/bes_timeout_error.json.baseline.http_header
@@ -1,7 +1,1 @@
-HTTP/1.1 504 Gateway Timeout
-Server: Apache-Coyote/1.1
-Content-Description: Error Object
-Content-Type: application/json
-Transfer-Encoding: chunked
-Date: Tue, 16 May 2017 21:22:06 GMT
-
+HTTP/1.1 504

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.ascii
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.ascii
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<162
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.ascii
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.ascii
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.ascii
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.ascii
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dap
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dap
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap?dap4.ce=GSO_AVHRR|day_num>160,day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap?dap4.ce%3DGSO_AVHRR%7Cday_num%3E160%2Cday_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dap
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dap
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap?dap4.ce=GSO_AVHRR|day_num>160,day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap?dap4.ce%3DGSO_AVHRR%7Cday_num%3E160%2Cday_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dap
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dap
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap?dap4.ce=GSO_AVHRR|day_num>160,day_num<162
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap?dap4.ce%3DGSO_AVHRR%7Cday_num%3E160%2Cday_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dap.csv
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dap.csv
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap.csv?dap4.ce=GSO_AVHRR|day_num>160,day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap.csv?dap4.ce%3DGSO_AVHRR%7Cday_num%3E160%2Cday_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dap.csv
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dap.csv
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap.csv?dap4.ce=GSO_AVHRR|day_num>160,day_num<162
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap.csv?dap4.ce%3DGSO_AVHRR%7Cday_num%3E160%2Cday_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dap.csv
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dap.csv
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap.csv?dap4.ce=GSO_AVHRR|day_num>160,day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap.csv?dap4.ce%3DGSO_AVHRR%7Cday_num%3E160%2Cday_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.das
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.das
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.das
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.das
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.das
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.das
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<162
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dds
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dds
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<162
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dds
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dds
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dds
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dds
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr?dap4.ce=GSO_AVHRR|day_num>160,day_num<162
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr?dap4.ce%3DGSO_AVHRR%7Cday_num%3E160%2Cday_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr?dap4.ce=GSO_AVHRR|day_num>160,day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr?dap4.ce%3DGSO_AVHRR%7Cday_num%3E160%2Cday_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr?dap4.ce=GSO_AVHRR|day_num>160,day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr?dap4.ce%3DGSO_AVHRR%7Cday_num%3E160%2Cday_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr.html
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr.html
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.html?dap4.ce=GSO_AVHRR|day_num>160,day_num<162
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.html?dap4.ce%3DGSO_AVHRR%7Cday_num%3E160%2Cday_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr.html
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr.html
@@ -1,2 +1,3 @@
+# http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.html?dap4.ce=GSO_AVHRR|day_num>160,day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.html?dap4.ce%3DGSO_AVHRR%7Cday_num%3E160%2Cday_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr.html
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr.html
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.html?dap4.ce=GSO_AVHRR|day_num>160,day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.html?dap4.ce%3DGSO_AVHRR%7Cday_num%3E160%2Cday_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr.xml
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr.xml
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.xml?dap4.ce=GSO_AVHRR|day_num>160,day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.xml?dap4.ce%3DGSO_AVHRR%7Cday_num%3E160%2Cday_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr.xml
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr.xml
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.xml?dap4.ce=GSO_AVHRR|day_num>160,day_num<162
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.xml?dap4.ce%3DGSO_AVHRR%7Cday_num%3E160%2Cday_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr.xml
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr.xml
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.xml?dap4.ce=GSO_AVHRR|day_num>160,day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.xml?dap4.ce%3DGSO_AVHRR%7Cday_num%3E160%2Cday_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dods
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dods
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dods
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dods
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dods
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dods
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<162
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.html
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.html
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.html
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.html
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.html
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.html
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<162
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.info
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.info
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<162
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.info
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.info
@@ -1,2 +1,3 @@
+# http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.info
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.info
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<162
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C162
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.ascii
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.ascii
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.ascii
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.ascii
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<170
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.ascii
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.ascii
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.ascii?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dap
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dap
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap?dap4.ce=GSO_AVHRR|160<day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap?dap4.ce%3DGSO_AVHRR%7C160%3Cday_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dap
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dap
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap?dap4.ce=GSO_AVHRR|160<day_num<170
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap?dap4.ce%3DGSO_AVHRR%7C160%3Cday_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dap
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dap
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap?dap4.ce=GSO_AVHRR|160<day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap?dap4.ce%3DGSO_AVHRR%7C160%3Cday_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dap.csv
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dap.csv
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap.csv?dap4.ce=GSO_AVHRR|160<day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap.csv?dap4.ce%3DGSO_AVHRR%7C160%3Cday_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dap.csv
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dap.csv
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap.csv?dap4.ce=GSO_AVHRR|160<day_num<170
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap.csv?dap4.ce%3DGSO_AVHRR%7C160%3Cday_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dap.csv
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dap.csv
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap.csv?dap4.ce=GSO_AVHRR|160<day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dap.csv?dap4.ce%3DGSO_AVHRR%7C160%3Cday_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.das
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.das
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<170
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.das
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.das
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.das
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.das
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.das?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dds
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dds
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<170
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dds
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dds
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dds
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dds
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dds?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr?dap4.ce=GSO_AVHRR|160<day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr?dap4.ce%3DGSO_AVHRR%7C160%3Cday_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr?dap4.ce=GSO_AVHRR|160<day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr?dap4.ce%3DGSO_AVHRR%7C160%3Cday_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr?dap4.ce=GSO_AVHRR|160<day_num<170
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr?dap4.ce%3DGSO_AVHRR%7C160%3Cday_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr.html
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr.html
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.html?dap4.ce=GSO_AVHRR|160<day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.html?dap4.ce%3DGSO_AVHRR%7C160%3Cday_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr.html
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr.html
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.html?dap4.ce=GSO_AVHRR|160<day_num<170
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.html?dap4.ce%3DGSO_AVHRR%7C160%3Cday_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr.html
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr.html
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.html?dap4.ce=GSO_AVHRR|160<day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.html?dap4.ce%3DGSO_AVHRR%7C160%3Cday_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr.xml
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr.xml
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.xml?dap4.ce=GSO_AVHRR|160<day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.xml?dap4.ce%3DGSO_AVHRR%7C160%3Cday_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr.xml
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr.xml
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.xml?dap4.ce=GSO_AVHRR|160<day_num<170
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.xml?dap4.ce%3DGSO_AVHRR%7C160%3Cday_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr.xml
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr.xml
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.xml?dap4.ce=GSO_AVHRR|160<day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dmr.xml?dap4.ce%3DGSO_AVHRR%7C160%3Cday_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dods
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dods
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<170
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dods
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dods
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dods
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dods
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.dods?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.html
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.html
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.html
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.html
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<170
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.html
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.html
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.html?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.info
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.info
@@ -1,2 +1,2 @@
-url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<170
+url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.info
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.info
@@ -1,2 +1,3 @@
+# url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C170
 -s

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.info
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.info
@@ -1,3 +1,4 @@
+# In test URL below, parameters are encoded to be allowed by Tomcat instances fixed for CVE-2016-6816.
 # url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?&GSO_AVHRR.day_num>160&GSO_AVHRR.day_num<170
 url = http://localhost:8080/opendap/data/ff/1998-6-avhrr.dat.info?%26GSO_AVHRR.day_num%3E160%26GSO_AVHRR.day_num%3C170
 -s

--- a/hyrax_tests/testGrind
+++ b/hyrax_tests/testGrind
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+# Usage: testGrind [value for catalina_home] [tests to run]
 
 # Provide a way to set CATALINA_HOME when it's not set in the shell.
 CATALINA_HOME="${CATALINA_HOME:-$1}"
@@ -9,6 +10,9 @@ then
     exit 1
 fi
 
+TESTS=${2:-"3 13 14 15 17 24 25 26 35 36 37 43 44 45 53 54 55"}
+echo "TESTS: $TESTS"
+
 # olfs_log_dir="/etc/olfs/logs"
 olfs_log_dir="$CATALINA_HOME/webapps/opendap/WEB-INF/conf/logs"
 
@@ -17,7 +21,7 @@ flush_list="${olfs_log_dir}/BESCommands.log ${olfs_log_dir}/HyraxAccess.log ${ol
 lap_count=0
 status=0
 while [  $status -eq 0 ]; do
-    ./hyraxTest -j5 3 13 14 15 17 24 25 26 35 36 37 43 44 45 53 54 55 > mk.log 2>&1
+    ./hyraxTest $TESTS > mk.log 2>&1
     status=$?
     echo "Test pass: $lap_count     status: $status"
     if [ $status -ne 0 ]

--- a/hyrax_tests/testGrind
+++ b/hyrax_tests/testGrind
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Usage: testGrind [value for catalina_home] [tests to run]
+# Usage: testGrind [value for catalina_home] [processes] [num laps] [tests to run]
 
 # Provide a way to set CATALINA_HOME when it's not set in the shell.
 CATALINA_HOME="${CATALINA_HOME:-$1}"
@@ -10,30 +10,46 @@ then
     exit 1
 fi
 
-TESTS=${2:-"3 13 14 15 17 24 25 26 35 36 37 43 44 45 53 54 55"}
+PROCS=${2:-"9"}
+echo "PROCS: $PROCS"
+
+# num laps is the number of failing laps
+num_laps=${3:-1}
+echo "num laps: $num_laps"
+
+TESTS=${4:-"3 13 14 15 17 24 25 26 35 36 37 43 44 45 53 54 55"}
 echo "TESTS: $TESTS"
+
+PATH=/Users/jimg/src/opendap/hyrax_git/build/bin:/Users/jimg/src/opendap/hyrax_git/build/deps/bin:$PATH
+echo "which getdap4: `which getdap4`"
 
 # olfs_log_dir="/etc/olfs/logs"
 olfs_log_dir="$CATALINA_HOME/webapps/opendap/WEB-INF/conf/logs"
 
-flush_list="${olfs_log_dir}/BESCommands.log ${olfs_log_dir}/HyraxAccess.log ${olfs_log_dir}/error.log $CATALINA_HOME/logs/catalina.out";
+flush_list="${olfs_log_dir}/BESCommands.log ${olfs_log_dir}/HyraxAccess.log ${olfs_log_dir}/HyraxErrors.log $CATALINA_HOME/logs/catalina.out";
 
+fail_count=0
 lap_count=0
 status=0
-while [  $status -eq 0 ]; do
-    ./hyraxTest $TESTS > mk.log 2>&1
+while [  $fail_count -lt $num_laps ]; do
+    # echo "Flushing $flush_list";
+
+    for flush_me in $flush_list
+    do
+        >  ${flush_me};
+    done
+
+    echo "./hyraxTest --jobs=$PROCS $TESTS > mk-$fail_count.log 2>&1"
+    ./hyraxTest --jobs=$PROCS $TESTS > mk-$fail_count.log 2>&1
     status=$?
+
     echo "Test pass: $lap_count     status: $status"
     if [ $status -ne 0 ]
     then
         echo "FAIL DETECTED!!!"
-    else
-        echo "Flushing $flush_list";
-        for flush_me in $flush_list
-        do
-            echo -n "" >  ${flush_me};
-        done
+        let fail_count=$fail_count+1
     fi
-    let lap_count=lap_count+1 
+
+    let lap_count=lap_count+1
 done
  

--- a/src/opendap/bes/dap2Responders/BesApi.java
+++ b/src/opendap/bes/dap2Responders/BesApi.java
@@ -89,6 +89,7 @@ public class BesApi {
     public static final String W10N_FLATTEN   = "w10nFlatten";
     public static final String W10N_TRAVERSE   = "w10nTraverse";
 
+    public static final String REQUEST_ID      = "reqID";
 
     private static final Namespace BES_NS = opendap.namespaces.BES.BES_NS;
 
@@ -1475,11 +1476,8 @@ public class BesApi {
     public void besTransaction(String dataSource,  Document request, OutputStream os)
             throws BadConfigurationException, IOException, PPTException, BESError {
 
-
-
         log.debug("besTransaction() started.");
         log.debug("besTransaction() request document: \n-----------\n"+ getDocumentAsString(request)+"-----------\n");
-
 
         BES bes = BESManager.getBES(dataSource);
         int bes_timeout_seconds = bes.getTimeout()/1000;
@@ -2242,10 +2240,7 @@ public class BesApi {
 
 
         Element e, request = new Element("request", BES_NS);
-
-        String reqID = Thread.currentThread().getName()+":"+ Thread.currentThread().getId();
-
-        request.setAttribute("reqID",reqID);
+        request.setAttribute(REQUEST_ID,getRequestIdBase());
 
 
         if(xdap_accept!=null)
@@ -2305,11 +2300,7 @@ public class BesApi {
 
         Element e, request = new Element("request", BES_NS);
 
-
-        String reqID = Thread.currentThread().getName()+":"+ Thread.currentThread().getId();
-
-
-        request.setAttribute("reqID",reqID);
+        request.setAttribute(REQUEST_ID,getRequestIdBase());
 
 
         request.addContent(setContextElement(EXPLICIT_CONTAINERS_CONTEXT,"no"));
@@ -2355,11 +2346,7 @@ public class BesApi {
 
 
         Element request = new Element("request", BES_NS);
-
-        String reqID = "["+Thread.currentThread().getName()+":"+
-                Thread.currentThread().getId()+":bes_request]";
-
-        request.setAttribute("reqID",reqID);
+        request.setAttribute(REQUEST_ID,getRequestIdBase());
 
         request.addContent(setContextElement(EXPLICIT_CONTAINERS_CONTEXT,"no"));
         request.addContent(setContextElement(ERRORS_CONTEXT,XML_ERRORS));
@@ -2415,9 +2402,7 @@ public class BesApi {
 
 
         Element e, request = new Element("request", BES_NS);
-        String reqID = "["+Thread.currentThread().getName()+":"+
-                Thread.currentThread().getId()+":bes_request]";
-        request.setAttribute("reqID",reqID);
+        request.setAttribute(REQUEST_ID,getRequestIdBase());
         request.addContent(setContextElement(ERRORS_CONTEXT,XML_ERRORS));
 
         e = new Element(type,BES_NS);
@@ -2580,10 +2565,9 @@ public class BesApi {
 
     }
 
-
-
-
-
+    private String getRequestIdBase(){
+        return "[thread:"+Thread.currentThread().getName()+"-"+ Thread.currentThread().getId()+"]";
+    }
 
 
 


### PR DESCRIPTION
1.  Encode URL parameters
2.  Truncate HTTP headers 