### PR TITLE
CoverageJSON Response Handler for OPeNDAP Project - OLFS

### DIFF
--- a/resources/hyrax/xsl/contents.xsl
+++ b/resources/hyrax/xsl/contents.xsl
@@ -313,6 +313,10 @@
                         <meta itemprop="name" content="{../@name}.rdf" />
                         <meta itemprop="encodingFormat" content="application/rdf+xml" />
                         <a itemprop="contentUrl" href="{encode-for-uri(../@name)}.rdf">rdf</a>&NBSP;</td>
+                    <td itemprop="distribution" itemscope="" itemtype="http://schema.org/DataDownload">
+                        <meta itemprop="name" content="{../@name}.cjson" />
+                        <meta itemprop="encodingFormat" content="application/json" />
+                        <a itemprop="contentUrl" href="{encode-for-uri(../@name)}.cjson">cov-json</a>&NBSP;</td>
                     <xsl:if test="$allowDirectDataSourceAccess='true'">
                         <td itemprop="distribution" itemscope="" itemtype="http://schema.org/DataDownload">
                             <meta itemprop="name" content="{../@name}" />

--- a/src/opendap/bes/BesDapDispatcher.java
+++ b/src/opendap/bes/BesDapDispatcher.java
@@ -246,11 +246,9 @@ public class BesDapDispatcher implements DispatchHandler {
         _responders.add( new Netcdf4(_systemPath, besApi, _addFileoutTypeSuffixToDownloadFilename));
         _responders.add( new XmlData(_systemPath, besApi, _addFileoutTypeSuffixToDownloadFilename));
 
-
         // DAP2 GeoTIFF Response
         Dap4Responder geoTiff = new GeoTiff(_systemPath, besApi, _addFileoutTypeSuffixToDownloadFilename);
         _responders.add(geoTiff);
-
 
         // DAP2 JPEG2000 Response
         Dap4Responder jp2 = new GmlJpeg2000(_systemPath, besApi, _addFileoutTypeSuffixToDownloadFilename);
@@ -264,6 +262,9 @@ public class BesDapDispatcher implements DispatchHandler {
         Dap4Responder ijsn = new Ijson(_systemPath, besApi, _addFileoutTypeSuffixToDownloadFilename);
         _responders.add(ijsn);
 
+        // DAP2 Cov-JSON Response
+        Dap4Responder cjson = new CovJson(_systemPath, besApi, _addFileoutTypeSuffixToDownloadFilename);
+        _responders.add(cjson);
 
         // DAP2 Metadata responses
         Dap4Responder d4r = new DDX(_systemPath, besApi);

--- a/src/opendap/bes/dap2Responders/BesApi.java
+++ b/src/opendap/bes/dap2Responders/BesApi.java
@@ -706,15 +706,39 @@ public class BesApi {
      * @throws PPTException              .
      */
     public void writeDap4DataAsJson(String dataSource,
-                                       QueryParameters qp,
-                                       int maxResponseSize,
-                                       OutputStream os)
+                                    QueryParameters qp,
+                                    int maxResponseSize,
+                                    OutputStream os)
             throws BadConfigurationException, BESError, IOException, PPTException {
 
         besTransaction(
-            dataSource,
-            getDap4DataAsJsonRequest(dataSource, qp, maxResponseSize),
-            os);
+                dataSource,
+                getDap4DataAsJsonRequest(dataSource, qp, maxResponseSize),
+                os);
+    }
+
+    /**
+     * Writes the NetCDF file out response for the dataSource to the passed
+     * stream.
+     *
+     * @param dataSource The requested DataSource
+     * @param qp The DAP4 query string parameters
+     * @param os         The Stream to which to write the response.
+     * @throws BadConfigurationException .
+     * @throws BESError                  .
+     * @throws IOException               .
+     * @throws PPTException              .
+     */
+    public void writeDap4DataAsCovJson(String dataSource,
+                                    QueryParameters qp,
+                                    int maxResponseSize,
+                                    OutputStream os)
+            throws BadConfigurationException, BESError, IOException, PPTException {
+
+        besTransaction(
+                dataSource,
+                getDap4DataAsCovJsonRequest(dataSource, qp, maxResponseSize),
+                os);
     }
 
     /**
@@ -2143,6 +2167,27 @@ public class BesApi {
             throws BadConfigurationException {
 
         return getDap4RequestDocument(DAP4_DATA, dataSource, qp, maxResponseSize, null, null, JSON, XML_ERRORS);
+
+
+    }
+
+    /**
+     *  Returns the XML data response for the passed dataSource
+     *  using the passed constraint expression.
+     * @param dataSource The data set whose DDS is being requested
+     * @param qp The DAP4 query string parameters associated wih the request.
+     * @param maxResponseSize Maximum allowable response size.
+     * @return The DDS request document.
+     * @throws BadConfigurationException When no BES can be found to
+     * service the request.
+     */
+    public Document getDap4DataAsCovJsonRequest(String dataSource,
+                                             QueryParameters qp,
+                                             int maxResponseSize
+    )
+            throws BadConfigurationException {
+
+        return getDap4RequestDocument(DAP4_DATA, dataSource, qp, maxResponseSize, null, null, COV_JSON, XML_ERRORS);
 
 
     }

--- a/src/opendap/bes/dap2Responders/BesApi.java
+++ b/src/opendap/bes/dap2Responders/BesApi.java
@@ -82,7 +82,7 @@ public class BesApi {
     public static final String GEOTIFF    = "geotiff";
     public static final String GMLJP2     = "jpeg2000";
     public static final String JSON       = "json";
-    public static final String COV_JSON   = "cov_json";
+    public static final String COV_JSON   = "covjson";
     public static final String IJSON      = "ijson";
     public static final String W10N       = "w10n";
     public static final String W10N_META      = "w10nMeta";

--- a/src/opendap/bes/dap2Responders/BesApi.java
+++ b/src/opendap/bes/dap2Responders/BesApi.java
@@ -82,6 +82,7 @@ public class BesApi {
     public static final String GEOTIFF    = "geotiff";
     public static final String GMLJP2     = "jpeg2000";
     public static final String JSON       = "json";
+    public static final String COV_JSON   = "cov_json";
     public static final String IJSON      = "ijson";
     public static final String W10N       = "w10n";
     public static final String W10N_META      = "w10nMeta";
@@ -812,7 +813,7 @@ public class BesApi {
 
 
     /**
-     * Writes the NetCDF file out response for the dataSource to the passed
+     * Writes the DAP4 XML data response for the dataSource to the passed
      * stream.
      *
      * @param dataSource The requested DataSource
@@ -840,7 +841,7 @@ public class BesApi {
 
 
     /**
-     * Writes the NetCDF file out response for the dataSource to the passed
+     * Writes the DAP4 json metadata response for the dataSource to the passed
      * stream.
      *
      * @param dataSource The requested DataSource
@@ -865,7 +866,7 @@ public class BesApi {
 
 
     /**
-     * Writes the NetCDF file out response for the dataSource to the passed
+     * Writes the DAP4 IJson metadata response for the dataSource to the passed
      * stream.
      *
      * @param dataSource The requested DataSource
@@ -891,7 +892,7 @@ public class BesApi {
 
 
     /**
-     * Writes the NetCDF file out response for the dataSource to the passed
+     * Writes the DAP2 IJson data response for the dataSource to the passed
      * stream.
      *
      * @param dataSource The requested DataSource
@@ -919,7 +920,7 @@ public class BesApi {
 
 
     /**
-     * Writes the NetCDF file out response for the dataSource to the passed
+     * Writes the DAP2 IJson metadata response for the dataSource to the passed
      * stream.
      *
      * @param dataSource The requested DataSource
@@ -946,7 +947,7 @@ public class BesApi {
     }
 
     /**
-     * Writes the NetCDF file out response for the dataSource to the passed
+     * Writes the DAP2 JSON data response for the dataSource to the passed
      * stream.
      *
      * @param dataSource The requested DataSource
@@ -960,13 +961,13 @@ public class BesApi {
      * @throws PPTException              .
      */
     public void writeDap2DataAsJson(String dataSource,
-                                       String constraintExpression,
-                                       String xdap_accept,
-                                       int maxResponseSize,
-                                       OutputStream os)
+                                    String constraintExpression,
+                                    String xdap_accept,
+                                    int maxResponseSize,
+                                    OutputStream os)
             throws BadConfigurationException, BESError, IOException, PPTException {
 
-         besTransaction(
+        besTransaction(
                 dataSource,
                 getDap2DataAsJsonRequest(dataSource, constraintExpression, xdap_accept, maxResponseSize),
                 os);
@@ -974,7 +975,39 @@ public class BesApi {
 
 
     /**
-     * Writes the NetCDF file out response for the dataSource to the passed
+     * Writes the DAP2 JSON data response for the dataSource to the passed
+     * stream.
+     *
+     * @param dataSource The requested DataSource
+     * @param constraintExpression The constraintElement expression to be applied to
+     *                             the request..
+     * @param xdap_accept The version of the DAP to use in building the response.
+     * @param os         The Stream to which to write the response.
+     * @throws BadConfigurationException .
+     * @throws BESError                  .
+     * @throws IOException               .
+     * @throws PPTException              .
+     */
+    public void writeDap2DataAsCovJson(String dataSource,
+                                    String constraintExpression,
+                                    String xdap_accept,
+                                    int maxResponseSize,
+                                    OutputStream os)
+            throws BadConfigurationException, BESError, IOException, PPTException {
+
+        besTransaction(
+                dataSource,
+                getDap2DataAsCovJsonRequest(
+                        dataSource,
+                        constraintExpression,
+                        xdap_accept,
+                        maxResponseSize),
+                        os);
+    }
+
+
+    /**
+     * Write DAP2 metadata as JSON for the dataSource to the passed
      * stream.
      *
      * @param dataSource The requested DataSource
@@ -1002,7 +1035,7 @@ public class BesApi {
 
 
     /**
-     * Writes the NetCDF file out response for the dataSource to the passed
+     * Writes the w10n Json response for the dataSource to the passed
      * stream.
      *
      * @param dataSource The requested DataSource
@@ -1969,6 +2002,26 @@ public class BesApi {
             throws BadConfigurationException {
 
         return getDap2RequestDocument(DAP2_DATA, dataSource, ce, xdap_accept, maxResponseSize, null, null, JSON, XML_ERRORS);
+
+    }
+    /**
+     *  Returns the XML data response for the passed dataSource
+     *  using the passed constraint expression.
+     * @param dataSource The data set whose DDS is being requested
+     * @param ce The constraint expression to apply.
+     * @param xdap_accept The version of the DAP to use in building the response.
+     * @param maxResponseSize Maximum allowable response size.
+     * @return The DDS request document.
+     * @throws BadConfigurationException When no BES can be found to
+     * service the request.
+     */
+    public Document getDap2DataAsCovJsonRequest(String dataSource,
+                                             String ce,
+                                             String xdap_accept,
+                                             int maxResponseSize)
+            throws BadConfigurationException {
+
+        return getDap2RequestDocument(DAP2_DATA, dataSource, ce, xdap_accept, maxResponseSize, null, null, COV_JSON, XML_ERRORS);
 
     }
     /**

--- a/src/opendap/bes/dap2Responders/CovJson.java
+++ b/src/opendap/bes/dap2Responders/CovJson.java
@@ -1,0 +1,132 @@
+/*
+ * /////////////////////////////////////////////////////////////////////////////
+ * // This file is part of the "Hyrax Data Server" project.
+ * //
+ * //
+ * // Copyright (c) 2013 OPeNDAP, Inc.
+ * // Author: Nathan David Potter  <ndp@opendap.org>
+ * //
+ * // This library is free software; you can redistribute it and/or
+ * // modify it under the terms of the GNU Lesser General Public
+ * // License as published by the Free Software Foundation; either
+ * // version 2.1 of the License, or (at your option) any later version.
+ * //
+ * // This library is distributed in the hope that it will be useful,
+ * // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * // Lesser General Public License for more details.
+ * //
+ * // You should have received a copy of the GNU Lesser General Public
+ * // License along with this library; if not, write to the Free Software
+ * // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+ * //
+ * // You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+ * /////////////////////////////////////////////////////////////////////////////
+ */
+
+package opendap.bes.dap2Responders;
+
+import opendap.bes.Version;
+import opendap.bes.dap4Responders.Dap4Responder;
+import opendap.bes.dap4Responders.MediaType;
+import opendap.coreServlet.OPeNDAPException;
+import opendap.coreServlet.ReqInfo;
+import opendap.coreServlet.RequestCache;
+import opendap.coreServlet.Scrub;
+import opendap.dap.User;
+import org.slf4j.Logger;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.OutputStream;
+
+/**
+ * Responder that transmits JSON encoded DAP2 data to the client.
+ */
+public class CovJson extends Dap4Responder {
+
+    private Logger log;
+    private static String defaultRequestSuffix = ".cjson";
+
+    public CovJson(String sysPath, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        this(sysPath, null, defaultRequestSuffix, besApi, addTypeSuffixToDownloadFilename);
+    }
+
+    public CovJson(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi, boolean addTypeSuffixToDownloadFilename) {
+        super(sysPath, pathPrefix, requestSuffixRegex, besApi);
+        log = org.slf4j.LoggerFactory.getLogger(this.getClass());
+
+        addTypeSuffixToDownloadFilename(addTypeSuffixToDownloadFilename);
+        setServiceRoleId("http://services.opendap.org/dap2/data/covjson");
+        setServiceTitle("CovJson encoded DAP2 data.");
+        setServiceDescription("CovJson representation of the DAP2 Data Response object.");
+        setServiceDescriptionLink("http://docs.opendap.org/index.php/DAP4:_Specification_Volume_2#DAP2:_CovJson_Data_Service");
+
+        setNormativeMediaType(new opendap.http.mediaTypes.Json(getRequestSuffix()));
+
+        log.debug("Using RequestSuffix:              '{}'", getRequestSuffix());
+        log.debug("Using CombinedRequestSuffixRegex: '{}'", getCombinedRequestSuffixRegex());
+    }
+
+
+    public boolean isDataResponder(){ return true; }
+    public boolean isMetadataResponder(){ return false; }
+
+
+    @Override
+    public boolean matches(String relativeUrl, boolean checkWithBes){
+        return super.matches(relativeUrl,checkWithBes);
+    }
+
+
+    @Override
+    public void sendNormativeRepresentation(HttpServletRequest request, HttpServletResponse response) throws Exception {
+
+        String requestedResourceId = ReqInfo.getLocalUrl(request);
+        // String xmlBase = getXmlBase(request);
+        String constraintExpression = ReqInfo.getConstraintExpression(request);
+
+        String resourceID = getResourceId(requestedResourceId, false);
+
+
+        BesApi besApi = getBesApi();
+
+        log.debug("Sending {} for dataset: {}",getServiceTitle(),resourceID);
+
+        response.setHeader("Content-Disposition", " attachment; filename=\"" +getDownloadFileName(resourceID)+"\"");
+
+        Version.setOpendapMimeHeaders(request, response, besApi);
+
+        MediaType responseMediaType =  getNormativeMediaType();
+
+        // Stash the Media type in case there's an error. That way the error handler will know how to encode the error.
+        RequestCache.put(OPeNDAPException.ERROR_RESPONSE_MEDIA_TYPE_KEY, responseMediaType);
+
+        response.setContentType(responseMediaType.getMimeType());
+
+        Version.setOpendapMimeHeaders(request, response, besApi);
+
+        response.setHeader("Content-Description", getNormativeMediaType().getMimeType());
+
+        User user = new User(request);
+
+
+        OutputStream os = response.getOutputStream();
+
+        besApi.writeDap2DataAsCovJson(
+                resourceID,
+                constraintExpression,
+                "3.2",
+                user.getMaxResponseSize(),
+                os);
+
+        os.flush();
+        log.debug("Sent {}",getServiceTitle());
+
+
+
+    }
+
+
+
+}

--- a/src/opendap/bes/dap4Responders/DataResponse/CovJsonDR.java
+++ b/src/opendap/bes/dap4Responders/DataResponse/CovJsonDR.java
@@ -1,0 +1,144 @@
+/*
+ * /////////////////////////////////////////////////////////////////////////////
+ * // This file is part of the "Hyrax Data Server" project.
+ * //
+ * //
+ * // Copyright (c) 2013 OPeNDAP, Inc.
+ * // Author: Nathan David Potter  <ndp@opendap.org>
+ * //
+ * // This library is free software; you can redistribute it and/or
+ * // modify it under the terms of the GNU Lesser General Public
+ * // License as published by the Free Software Foundation; either
+ * // version 2.1 of the License, or (at your option) any later version.
+ * //
+ * // This library is distributed in the hope that it will be useful,
+ * // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * // Lesser General Public License for more details.
+ * //
+ * // You should have received a copy of the GNU Lesser General Public
+ * // License along with this library; if not, write to the Free Software
+ * // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+ * //
+ * // You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+ * /////////////////////////////////////////////////////////////////////////////
+ */
+
+package opendap.bes.dap4Responders.DataResponse;
+
+import opendap.bes.Version;
+import opendap.bes.dap2Responders.BesApi;
+import opendap.bes.dap4Responders.Dap4Responder;
+import opendap.bes.dap4Responders.MediaType;
+import opendap.coreServlet.OPeNDAPException;
+import opendap.coreServlet.ReqInfo;
+import opendap.coreServlet.RequestCache;
+import opendap.coreServlet.Scrub;
+import opendap.dap.User;
+import opendap.dap4.QueryParameters;
+import opendap.http.mediaTypes.Json;
+import org.slf4j.Logger;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.OutputStream;
+
+/**
+ * Responder that transmits JSON encoded DAP4 data to the client.
+ */
+public class CovJsonDR extends Dap4Responder {
+
+
+    private Logger log;
+    private static String defaultRequestSuffix = ".cjson";
+    // private String requestSuffix;
+
+
+
+    public CovJsonDR(String sysPath, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
+        this(sysPath, null, defaultRequestSuffix, besApi, addFileoutTypeSuffixToDownloadFilename);
+    }
+
+    public CovJsonDR(String sysPath, String pathPrefix, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
+        this(sysPath, pathPrefix, defaultRequestSuffix, besApi, addFileoutTypeSuffixToDownloadFilename);
+    }
+
+    public CovJsonDR(String sysPath, String pathPrefix, String requestSuffixRegex, BesApi besApi, boolean addFileoutTypeSuffixToDownloadFilename) {
+        super(sysPath, pathPrefix, requestSuffixRegex, besApi);
+        log = org.slf4j.LoggerFactory.getLogger(this.getClass());
+
+        addTypeSuffixToDownloadFilename(addFileoutTypeSuffixToDownloadFilename);
+        setServiceRoleId("http://services.opendap.org/dap4/data/json");
+        setServiceTitle("CovJsonDR Data Response");
+        setServiceDescription("CovJsonDR representation of the DAP4 Data Response object.");
+        setServiceDescriptionLink("http://docs.opendap.org/index.php/DAP4:_Specification_Volume_2#DAP4:_Data_Response");
+
+        setNormativeMediaType(new Json(getRequestSuffix()));
+
+        log.debug("Using RequestSuffix:              '{}'", getRequestSuffix());
+        log.debug("Using CombinedRequestSuffixRegex: '{}'", getCombinedRequestSuffixRegex());
+
+    }
+
+
+    public boolean isDataResponder(){ return true; }
+    public boolean isMetadataResponder(){ return false; }
+
+
+
+
+
+    public void sendNormativeRepresentation(HttpServletRequest request, HttpServletResponse response) throws Exception {
+
+        String requestedResourceId = ReqInfo.getLocalUrl(request);
+        // String xmlBase = getXmlBase(request);
+        QueryParameters qp = new  QueryParameters(request);
+
+        String resourceID = getResourceId(requestedResourceId, false);
+
+
+        BesApi besApi = getBesApi();
+
+        log.debug("Sending {} for dataset: {}",getServiceTitle(),resourceID);
+
+        response.setHeader("Content-Disposition", " attachment; filename=\"" +getDownloadFileName(resourceID)+"\"");
+
+        Version.setOpendapMimeHeaders(request, response, besApi);
+
+        MediaType responseMediaType =  getNormativeMediaType();
+
+        // Stash the Media type in case there's an error. That way the error handler will know how to encode the error.
+        RequestCache.put(OPeNDAPException.ERROR_RESPONSE_MEDIA_TYPE_KEY, responseMediaType);
+
+        response.setContentType(responseMediaType.getMimeType());
+
+        Version.setOpendapMimeHeaders(request, response, besApi);
+
+        response.setHeader("Content-Description", getNormativeMediaType().getMimeType());
+
+
+
+        User user = new User(request);
+
+
+        OutputStream os = response.getOutputStream();
+
+
+        besApi.writeDap4DataAsCovJson(
+                resourceID,
+                qp,
+                user.getMaxResponseSize(),
+                os);
+
+
+
+        os.flush();
+        log.debug("Sent {}",getServiceTitle());
+
+
+
+    }
+
+
+
+}

--- a/src/opendap/bes/dap4Responders/DataResponse/NormativeDR.java
+++ b/src/opendap/bes/dap4Responders/DataResponse/NormativeDR.java
@@ -94,6 +94,7 @@ public class NormativeDR extends Dap4Responder {
         addAltRepResponder(new GmlJpeg2000DR  (sysPath, pathPrefix, besApi, addTypeSuffixToDownloadFilename));
         addAltRepResponder(new JsonDR         (sysPath, pathPrefix, besApi, addTypeSuffixToDownloadFilename));
         addAltRepResponder(new IjsonDR        (sysPath, pathPrefix, besApi, addTypeSuffixToDownloadFilename));
+        addAltRepResponder(new CovJsonDR      (sysPath, pathPrefix, besApi, addTypeSuffixToDownloadFilename));
 
 
         log.debug("Using RequestSuffix:              '{}'", getRequestSuffix());


### PR DESCRIPTION
This is the initial pull request for the CoverageJSON Response Handler for OPeNDAP project. This project was an Oregon State University 2018 capstone project sponsored by NASA JPL. This response handler module, fileout_covjson, was modeled after the existing fileout_json response handler.

This pull request adds the ability to request CovJSON files from the OLFS via the .covjson suffix or via the "Get as CoverageJSON" button through a granule's html page. In addition, a "covjson" request link has also been added to the "DAP Response Links".

BES Pull Request Reference https://github.com/OPENDAP/bes/pull/164