### PR TITLE
Last minute changes for hyrax-1.15

### DIFF
--- a/resources/hyrax/xsl/node_contents.xsl
+++ b/resources/hyrax/xsl/node_contents.xsl
@@ -258,12 +258,15 @@
 
     <xsl:template name="DapServiceLinks" >
         <td align="left">
-            <b><a href="{encode-for-uri(@name)}.html">
+            <b>
+                <a href="{encode-for-uri(@name)}.html">
                 <span itemprop="name">
                     <xsl:value-of select="@name"/>
                 </span>
-            </a>
+                </a>
             </b>
+            <span class="small">(<a href="{encode-for-uri(@name)}.ifh">ifh</a>)</span>
+
         </td>
 
         <td align="center" nowrap="nowrap">


### PR DESCRIPTION
Where we try stuff we need to finalize before release.

## IFH
It looks like the IFH is at least ready for a more exposed public beta, and possibly ready to assume the role of the primary DAP2 Data Request Form (It's already in use in DAP4)

What should we do? Besides just making the IFH _*the*_ data request form we could make an intermediate step by advertising the IFH in the catalog UI rather than providing it as a hidden service endpoint (Not very RESTful.)  

So this first commit adds a small "(_ifh_)" link after each dataset in the catalog. The text could be changed (_beta_?)

<img width="277" alt="screen shot 2018-09-01 at 6 32 57 am" src="https://user-images.githubusercontent.com/8389499/44946416-ed301200-adb0-11e8-999d-0b2f04804048.png">

<img width="1286" alt="screen shot 2018-09-01 at 6 31 46 am" src="https://user-images.githubusercontent.com/8389499/44946406-c671db80-adb0-11e8-8026-40f12b41474b.png">
