### PR TITLE
Added a useful support email body to out JSP error pages

### DIFF
--- a/resources/hyrax/error/error400.jsp
+++ b/resources/hyrax/error/error400.jsp
@@ -1,9 +1,5 @@
 <%@ page import="opendap.bes.dap2Responders.BesApi" %>
 <%@ page import="opendap.coreServlet.ReqInfo" %>
-<%@ page import="opendap.bes.BadConfigurationException" %>
-<%@ page import="org.jdom.JDOMException" %>
-<%@ page import="opendap.ppt.PPTException" %>
-<%@ page import="opendap.bes.BESError" %>
 <%@ page import="opendap.coreServlet.OPeNDAPException" %>
 <%--
   ~ /////////////////////////////////////////////////////////////////////////////
@@ -46,6 +42,7 @@
     } catch (Exception e) { }
 
     String message = OPeNDAPException.getAndClearCachedErrorMessage();
+    String mailtoHrefAttributeValue = OPeNDAPException.getSupportMailtoLink(request,400,message,adminEmail);
 
 %>
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -96,8 +93,7 @@
             </p>
             <p align="left"> If you think that the server is broken (that the URL you submitted should have worked),
                 then please contact the OPeNDAP user support coordinator at:
-                <a href="mailto:<%= adminEmail %>"><%= adminEmail %>
-                </a>
+                <a href="<%=mailtoHrefAttributeValue%>"><%= adminEmail %></a>
             </p>
         </td>
     </tr>

--- a/resources/hyrax/error/error404.jsp
+++ b/resources/hyrax/error/error404.jsp
@@ -39,8 +39,8 @@
     try {
         adminEmail = besApi.getAdministrator(localUrl);
     } catch (Exception e) { }
-
     String message = OPeNDAPException.getAndClearCachedErrorMessage();
+    String mailtoHrefAttributeValue = OPeNDAPException.getSupportMailtoLink(request,404,message,adminEmail);
 %>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -76,7 +76,8 @@
             <blockquote> <p><strong><%= message %> </strong></p> </blockquote>
             <% } %>
             <p align="left">If you think that the server is broken (that the URL you submitted should have worked),
-                then please contact the OPeNDAP user support coordinator at: <a href="mailto:<%= adminEmail %>"><%= adminEmail %></a>
+                then please contact the OPeNDAP user support coordinator at:
+                <a href="<%=mailtoHrefAttributeValue%>"><%= adminEmail %></a>
             </p>
 
         </td>

--- a/resources/hyrax/error/error500.jsp
+++ b/resources/hyrax/error/error500.jsp
@@ -42,6 +42,7 @@
     } catch (Exception e) { }
 
     String message = OPeNDAPException.getAndClearCachedErrorMessage();
+    String mailtoHrefAttributeValue = OPeNDAPException.getSupportMailtoLink(request,500,message,adminEmail);
 
 %>
 <head>
@@ -84,7 +85,7 @@
 
             <p align="left">If you think that the server is broken (that the URL you submitted should have
                 worked), then please contact the OPeNDAP user support coordinator at:
-                <a href="mailto:<%= adminEmail %>"><%= adminEmail %></a>
+                <a href="<%= mailtoHrefAttributeValue %>"><%= adminEmail %></a>
             </p>
         </td>
     </tr>

--- a/resources/hyrax/error/error501.jsp
+++ b/resources/hyrax/error/error501.jsp
@@ -41,6 +41,7 @@
     } catch (Exception e) { }
 
     String message = OPeNDAPException.getAndClearCachedErrorMessage();
+    String mailtoHrefAttributeValue = OPeNDAPException.getSupportMailtoLink(request,501,message,adminEmail);
 %>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -76,7 +77,9 @@
       <blockquote> <p><strong><%= message %> </strong></p> </blockquote>
       <% } %>
 
-    <p align="left">If you think that the server is broken (that the URL you submitted should have worked), then please contact the OPeNDAP user support coordinator at: <a href="mailto:<%= adminEmail %>"><%= adminEmail %></a></p></td>
+    <p align="left">If you think that the server is broken (that the URL you submitted should have
+        worked), then please contact the OPeNDAP user support coordinator at:
+        <a href="<%= mailtoHrefAttributeValue %>"><%= adminEmail %></a></p></td>
   </tr>
 </table>
 <hr size="1" noshade="noshade" />

--- a/resources/hyrax/error/error502.jsp
+++ b/resources/hyrax/error/error502.jsp
@@ -39,9 +39,8 @@
         adminEmail = besApi.getAdministrator(localUrl);
     } catch (Exception e) {
     }
-
-
     String message = OPeNDAPException.getAndClearCachedErrorMessage();
+    String mailtoHrefAttributeValue = OPeNDAPException.getSupportMailtoLink(request,502,message,adminEmail);
 %>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -88,7 +87,7 @@
             <p align="left">If
                 you think that the server is broken (that the URL you submitted should
                 have worked), then please contact the OPeNDAP user support coordinator
-                at: <a href="mailto:<%= adminEmail %>"><%= adminEmail %>
+                at: <a href="<%= mailtoHrefAttributeValue %>"><%= adminEmail %>
                 </a></p></td>
     </tr>
     </tbody>

--- a/src/opendap/coreServlet/OPeNDAPException.java
+++ b/src/opendap/coreServlet/OPeNDAPException.java
@@ -29,10 +29,7 @@ package opendap.coreServlet;
 
 import opendap.bes.dap4Responders.MediaType;
 import opendap.http.mediaTypes.*;
-import opendap.http.mediaTypes.Dap4Error;
 import opendap.io.HyraxStringEncoding;
-import opendap.namespaces.DAP4;
-import org.jdom.Element;
 import org.jdom.output.Format;
 import org.jdom.output.XMLOutputter;
 import org.owasp.encoder.Encode;
@@ -41,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -602,5 +600,23 @@ public class OPeNDAPException extends Exception {
     }
 
 
+    public static String getSupportMailtoLink(HttpServletRequest request, int http_status, String errorMessage, String adminEmail){
+        String requestUrl = request.getRequestURL().toString();
+        String queryString = request.getQueryString();
+
+        StringBuilder mailtoHrefAttributeValue = new StringBuilder();
+        mailtoHrefAttributeValue.append("mailto:").append(adminEmail).append("?subject=Hyrax Error ").append(http_status);
+        mailtoHrefAttributeValue.append("&body=");
+
+        mailtoHrefAttributeValue.append("url: ").append(requestUrl);
+        if(queryString!=null && !queryString.isEmpty())
+            mailtoHrefAttributeValue.append("?").append(queryString);
+        mailtoHrefAttributeValue.append("%0A");
+
+        mailtoHrefAttributeValue.append("status: ").append(http_status).append("%0A");
+        mailtoHrefAttributeValue.append("message: ").append(errorMessage).append("%0A");
+        mailtoHrefAttributeValue.append("-- --%0A");
+        return Encode.forHtmlAttribute(mailtoHrefAttributeValue.toString());
+    }
 
 }


### PR DESCRIPTION
Now when you click the link the emailer get's the information to populate the message body with the request URL, http status, and error message text.