### PR TITLE
Fixed IFH on CentOS-6

### DIFF
--- a/src/opendap/bes/dap2Responders/Dap2IFH.java
+++ b/src/opendap/bes/dap2Responders/Dap2IFH.java
@@ -153,8 +153,8 @@ public class Dap2IFH extends Dap4Responder {
             // a little simpler to use. It makes it easy to set input parameters for the stylesheet.
             // See the source code in opendap.xml.Transformer for more.
             Transformer transformer = new Transformer(xsltDocName);
-
-            transformer.setParameter("serviceContext", request.getServletContext().getContextPath());
+            // transformer.setParameter("serviceContext", request.getServletContext().getContextPath()); // This is ServletAPI-3.0
+            transformer.setParameter("serviceContext", request.getContextPath()); // This is ServletAPI-2.5 (Tomcat 6 stopped here)
             transformer.setParameter("docsService", oreq.getDocsServiceLocalID());
             transformer.setParameter("HyraxVersion", Version.getHyraxVersionString());
             transformer.setParameter("JsonLD", jsonLD);

--- a/src/opendap/bes/dap4Responders/DatasetMetadata/HtmlDMR.java
+++ b/src/opendap/bes/dap4Responders/DatasetMetadata/HtmlDMR.java
@@ -140,7 +140,8 @@ public class HtmlDMR extends Dap4Responder {
             // a little simpler to use. It makes it easy to set input parameters for the stylesheet.
             // See the source code for opendap.xml.Transformer for more.
             Transformer transformer = new Transformer(xsltDocName);
-            transformer.setParameter("serviceContext", request.getServletContext().getContextPath());
+            // transformer.setParameter("serviceContext", request.getServletContext().getContextPath()); // This is ServletAPI-3.0
+            transformer.setParameter("serviceContext", request.getContextPath()); // This is ServletAPI-2.5 (Tomcat 6 stopped here)
             transformer.setParameter("docsService", oreq.getDocsServiceLocalID());
             transformer.setParameter("HyraxVersion", Version.getHyraxVersionString());
             transformer.setParameter("JsonLD", getDatasetJsonLD(collectionUrl,dmr));


### PR DESCRIPTION
Regressed the  IFH from ServletAPI-3.0 back to ServletAPI-2.5 for compatibility with Tomcat-6.0.24, which is the latest Tomcat available via yum on CentOS-6.latest