### PR TITLE
olfs: Added support email links to IFH pages and HTML catalog pages.

### DIFF
--- a/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.html.baseline
+++ b/hyrax_tests/dap2_ssfunc/1998-6-avhrr.dat_DateTimeConstraint_01.html.baseline
@@ -323,8 +323,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/ff/1998-6-avhrr.dat.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/ff/1998-6-avhrr.dat.html%0A# query_string: DODS_URL&amp;date_time%28%221998%2F160%3A17%3A45%3A00%22%29%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-Basic.html.baseline
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-Basic.html.baseline
@@ -256,8 +256,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/nc/coads_climatology.nc.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/nc/coads_climatology.nc.html%0A# query_string: geogrid(SST,61,-82,38,-19)%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.html.baseline
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-TimeSelect.html.baseline
@@ -256,8 +256,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/nc/coads_climatology.nc.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/nc/coads_climatology.nc.html%0A# query_string: geogrid%28SST%2C61%2C-82%2C38%2C-19%2C%22TIME%3C1500%22%29%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-WholeArray.html.baseline
+++ b/hyrax_tests/dap2_ssfunc/coads_climatology.nc_geogrid-WholeArray.html.baseline
@@ -256,8 +256,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/nc/coads_climatology.nc.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/nc/coads_climatology.nc.html%0A# query_string: geogrid(SST,379,-89,0,89)%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/ff/1998-6-avhrr.dat.dmr.html.baseline
+++ b/hyrax_tests/ff/1998-6-avhrr.dat.dmr.html.baseline
@@ -597,8 +597,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/ff/1998-6-avhrr.dat.dmr.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/ff/1998-6-avhrr.dat.dmr.html%0A# query_string: n/a%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/ff/1998-6-avhrr.dat.html.baseline
+++ b/hyrax_tests/ff/1998-6-avhrr.dat.html.baseline
@@ -594,8 +594,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/ff/1998-6-avhrr.dat.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/ff/1998-6-avhrr.dat.html%0A# query_string: n/a%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr.html.baseline
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.dmr.html.baseline
@@ -597,8 +597,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/ff/1998-6-avhrr.dat.dmr.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/ff/1998-6-avhrr.dat.dmr.html%0A# query_string: dap4.ce=GSO_AVHRR%7Cday_num%3E160%2Cday_num%3C162%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.html.baseline
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint01.html.baseline
@@ -594,8 +594,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/ff/1998-6-avhrr.dat.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/ff/1998-6-avhrr.dat.html%0A# query_string: GSO_AVHRR&amp;GSO_AVHRR.day_num%3E160&amp;GSO_AVHRR.day_num%3C162%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr.html.baseline
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.dmr.html.baseline
@@ -597,8 +597,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/ff/1998-6-avhrr.dat.dmr.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/ff/1998-6-avhrr.dat.dmr.html%0A# query_string: dap4.ce=GSO_AVHRR%7C160%3Cday_num%3C170%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.html.baseline
+++ b/hyrax_tests/ff/1998-6-avhrr.dat_RelationalConstraint02.html.baseline
@@ -594,8 +594,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/ff/1998-6-avhrr.dat.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/ff/1998-6-avhrr.dat.html%0A# query_string: GSO_AVHRR&amp;GSO_AVHRR.day_num%3E160&amp;GSO_AVHRR.day_num%3C170%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/ff/avhrr.dat.dmr.html.baseline
+++ b/hyrax_tests/ff/avhrr.dat.dmr.html.baseline
@@ -726,8 +726,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/ff/avhrr.dat.dmr.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/ff/avhrr.dat.dmr.html%0A# query_string: n/a%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/ff/avhrr.dat.html.baseline
+++ b/hyrax_tests/ff/avhrr.dat.html.baseline
@@ -723,8 +723,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/ff/avhrr.dat.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/ff/avhrr.dat.html%0A# query_string: n/a%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/ff/gsodock.dat.dmr.html.baseline
+++ b/hyrax_tests/ff/gsodock.dat.dmr.html.baseline
@@ -768,8 +768,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/ff/gsodock.dat.dmr.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/ff/gsodock.dat.dmr.html%0A# query_string: n/a%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/ff/gsodock.dat.html.baseline
+++ b/hyrax_tests/ff/gsodock.dat.html.baseline
@@ -770,8 +770,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/ff/gsodock.dat.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/ff/gsodock.dat.html%0A# query_string: n/a%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/ff/gsodock.dat_URI_GSO-Dock.Air_Temp_URI_GSO-Dock.Depth.dmr.html.baseline
+++ b/hyrax_tests/ff/gsodock.dat_URI_GSO-Dock.Air_Temp_URI_GSO-Dock.Depth.dmr.html.baseline
@@ -317,8 +317,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/ff/gsodock.dat.dmr.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/ff/gsodock.dat.dmr.html%0A# query_string: dap4.ce=URI_GSO-Dock.Air_Temp;URI_GSO-Dock.Depth%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/ff/gsodock.dat_URI_GSO-Dock.Air_Temp_URI_GSO-Dock.Depth.html.baseline
+++ b/hyrax_tests/ff/gsodock.dat_URI_GSO-Dock.Air_Temp_URI_GSO-Dock.Depth.html.baseline
@@ -309,8 +309,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/ff/gsodock.dat.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/ff/gsodock.dat.html%0A# query_string: URI_GSO-Dock.Air_Temp,URI_GSO-Dock.Depth%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/hdf4/S2000415.hdf.dmr.html.baseline
+++ b/hyrax_tests/hdf4/S2000415.hdf.dmr.html.baseline
@@ -3069,8 +3069,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/hdf4/S2000415.HDF.gz.dmr.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/hdf4/S2000415.HDF.gz.dmr.html%0A# query_string: n/a%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/hdf4/S2000415.hdf.html.baseline
+++ b/hyrax_tests/hdf4/S2000415.hdf.html.baseline
@@ -3051,8 +3051,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/hdf4/S2000415.HDF.gz.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/hdf4/S2000415.HDF.gz.html%0A# query_string: n/a%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/hdf4/S2000415.hdf_ArraySubset.dmr.html.baseline
+++ b/hyrax_tests/hdf4/S2000415.hdf_ArraySubset.dmr.html.baseline
@@ -1276,8 +1276,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/hdf4/S2000415.HDF.gz.dmr.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/hdf4/S2000415.HDF.gz.dmr.html%0A# query_string: dap4.ce=NSCAT_Rev_20_Num_Beam_34%5B0%3A10%3A457%5D%5B0%3A4%3A23%5D%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/hdf4/S2000415.hdf_ArraySubset.html.baseline
+++ b/hyrax_tests/hdf4/S2000415.hdf_ArraySubset.html.baseline
@@ -1267,8 +1267,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/hdf4/S2000415.HDF.gz.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/hdf4/S2000415.HDF.gz.html%0A# query_string: NSCAT_Rev_20_Num_Beam_34%5B0%3A10%3A457%5D%5B0%3A4%3A23%5D%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/nc3/bears.nc.dmr.html.baseline
+++ b/hyrax_tests/nc3/bears.nc.dmr.html.baseline
@@ -644,8 +644,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/nc/bears.nc.dmr.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/nc/bears.nc.dmr.html%0A# query_string: n/a%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/nc3/bears.nc.html.baseline
+++ b/hyrax_tests/nc3/bears.nc.html.baseline
@@ -618,8 +618,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/nc/bears.nc.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/nc/bears.nc.html%0A# query_string: n/a%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/nc3/bears.nc_bears_aloan_i.dmr.html.baseline
+++ b/hyrax_tests/nc3/bears.nc_bears_aloan_i.dmr.html.baseline
@@ -435,8 +435,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/nc/bears.nc.dmr.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/nc/bears.nc.dmr.html%0A# query_string: dap4.ce=bears;aloan;i%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/nc3/bears.nc_bears_aloan_i.html.baseline
+++ b/hyrax_tests/nc3/bears.nc_bears_aloan_i.html.baseline
@@ -411,8 +411,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/nc/bears.nc.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/nc/bears.nc.html%0A# query_string: bears,aloan,i%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/nc3/fnoc1.nc.html.baseline
+++ b/hyrax_tests/nc3/fnoc1.nc.html.baseline
@@ -573,8 +573,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/nc/fnoc1.nc.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/nc/fnoc1.nc.html%0A# query_string: n/a%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/nc3/fnoc1.nc_lat.dmr.html.baseline
+++ b/hyrax_tests/nc3/fnoc1.nc_lat.dmr.html.baseline
@@ -266,8 +266,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/nc/fnoc1.nc.dmr.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/nc/fnoc1.nc.dmr.html%0A# query_string: dap4.ce=lat%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/hyrax_tests/nc3/fnoc1.nc_lat.html.baseline
+++ b/hyrax_tests/nc3/fnoc1.nc_lat.html.baseline
@@ -248,8 +248,14 @@
             </tr>
          </table>
       </form>
-      <h3>OPeNDAP Hyrax (Not.A.Release) <br/>
-         <a href="/opendap/docs/">Documentation</a>
+      <h3>OPeNDAP Hyrax (Not.A.Release)
+                    <div>
+            <a href="/opendap/docs/">Documentation</a>
+            <span class="small"
+                  style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+               <a href="mailto:support@opendap.org?subject=Hyrax Usage Question&amp;body=%0A%0A%0A%0A%0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A# %0A# We're sorry you had a problem using the server.%0A# Please use the space above to describe what you%0A# were trying to do and we will try to assist you.%0A# Thanks,%0A# OPeNDAP Support.%0A# %0A# -- -- -- hyrax location info, please include -- -- --%0A# %0A# request_url: http://localhost:8080/opendap/hyrax/data/nc/fnoc1.nc.html%0A# protocol: HTTP/1.1%0A# server: localhost%0A# port: 8080%0A# javax.servlet.forward.request_uri: /opendap/data/nc/fnoc1.nc.html%0A# query_string: lat%0A# status: 200%0A# %0A# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A">Questions? Contact Support</a>
+            </span>
+         </div>
       </h3>
       <script type="application/ld+json">
 {

--- a/resources/hyrax/xsl/dap2_ifh.xsl
+++ b/resources/hyrax/xsl/dap2_ifh.xsl
@@ -32,6 +32,7 @@
     <xsl:param name="docsService"/>
     <xsl:param name="HyraxVersion"/>
     <xsl:param name="JsonLD"/>
+    <xsl:param name="supportLink"/>
     <xsl:param name="userId" />
     <xsl:param name="loginLink" />
     <xsl:param name="logoutLink" />
@@ -180,8 +181,13 @@
                 <!-- ****************************************************** -->
                 <!--         HERE IS THE HYRAX VERSION NUMBER               -->
                 <!--                                                        -->
-                <h3>OPeNDAP Hyrax (<xsl:value-of select="$HyraxVersion"/>) <br/>
-                    <a href="{$docsService}/">Documentation</a>
+                <h3>OPeNDAP Hyrax (<xsl:value-of select="$HyraxVersion"/>)
+                    <div>
+                        <a href="{$docsService}/">Documentation</a>
+                        <span class="small" style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+                            <a href="{$supportLink}">Questions? Contact Support</a>
+                        </span>
+                    </div>
                 </h3>
 
                 <xsl:if test="$JsonLD">

--- a/resources/hyrax/xsl/dap4_ifh.xsl
+++ b/resources/hyrax/xsl/dap4_ifh.xsl
@@ -32,6 +32,7 @@
     <xsl:param name="docsService"/>
     <xsl:param name="HyraxVersion"/>
     <xsl:param name="JsonLD"/>
+    <xsl:param name="supportLink"/>
     <xsl:param name="userId" />
     <xsl:param name="loginLink" />
     <xsl:param name="logoutLink" />
@@ -181,8 +182,13 @@
                 <!-- ****************************************************** -->
                 <!--         HERE IS THE HYRAX VERSION NUMBER               -->
                 <!--                                                        -->
-                <h3>OPeNDAP Hyrax (<xsl:value-of select="$HyraxVersion"/>) <br/>
-                    <a href="{$docsService}/">Documentation</a>
+                <h3>OPeNDAP Hyrax (<xsl:value-of select="$HyraxVersion"/>)
+                    <div>
+                        <a href="{$docsService}/">Documentation</a>
+                        <span class="small" style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+                            <a href="{$supportLink}">Questions? Contact Support</a>
+                        </span>
+                    </div>
                 </h3>
 
                 <xsl:if test="$JsonLD">

--- a/resources/hyrax/xsl/node_contents.xsl
+++ b/resources/hyrax/xsl/node_contents.xsl
@@ -38,6 +38,7 @@
     <xsl:param name="viewersService" />
     <xsl:param name="collectionURL" />
     <xsl:param name="catalogPublisherJsonLD" />
+    <xsl:param name="supportLink"/>
     <xsl:param name="allowDirectDataSourceAccess" />
     <xsl:param name="userId" />
     <xsl:param name="loginLink" />
@@ -238,15 +239,17 @@
             <!--         HERE IS THE HYRAX VERSION NUMBER               -->
             <!--                                                        -->
             <h3>OPeNDAP Hyrax (<xsl:value-of select="$HyraxVersion"/>)
-
-                <xsl:if test="bes:dataset/@name='/'">
+                <!-- xsl:if test="bes:dataset/@name='/'">
                     <span class="uuid">
                         ServerUUID=e93c3d09-a5d9-49a0-a912-a0ca16430b91-contents
                     </span>
-                </xsl:if>
-
-                <br/>
-                <a href='{$docsService}/'>Documentation</a>
+                </xsl:if -->
+                <div>
+                    <a href="{$docsService}/">Documentation</a>
+                    <span class="small" style="font-weight: normal; display: inline; float: right; padding-right: 10px;">
+                        <a href="{$supportLink}">Questions? Contact Support</a>
+                    </span>
+                </div>
             </h3>
             <xsl:call-template name="json-ld-DataCatalog"/>
         </body>

--- a/src/opendap/bes/DirectoryDispatchHandler.java
+++ b/src/opendap/bes/DirectoryDispatchHandler.java
@@ -248,12 +248,17 @@ public class DirectoryDispatchHandler implements DispatchHandler {
         if(BesDapDispatcher.useDAP2ResourceUrlResponse())
             xsltDoc = systemPath + "/xsl/node_contents.xsl";
 
+        String requestedResourceId = ReqInfo.getLocalUrl(request);
+        String supportEmail = _besApi.getSupportEmail(requestedResourceId);
+        String mailtoHrefAttributeValue = OPeNDAPException.getSupportMailtoLink(request,200,"n/a",supportEmail);
+
         Transformer transformer = new Transformer(xsltDoc);
         transformer.setParameter("dapService",oreq.getServiceLocalId());
         transformer.setParameter("docsService",oreq.getDocsServiceLocalID());
         transformer.setParameter("viewersService", ViewersServlet.getServiceId());
         transformer.setParameter("collectionURL",collectionURL);
         transformer.setParameter("catalogPublisherJsonLD",publisherJsonLD);
+        transformer.setParameter("supportLink", mailtoHrefAttributeValue);
         if(BesDapDispatcher.allowDirectDataSourceAccess())
             transformer.setParameter("allowDirectDataSourceAccess","true");
 

--- a/src/opendap/bes/dap2Responders/BesApi.java
+++ b/src/opendap/bes/dap2Responders/BesApi.java
@@ -96,7 +96,7 @@ public class BesApi implements Cloneable {
     public static final String SHOW_BES_KEY    = "showBesKey";
     public static final String VALUE           = "value";
     public static final String SUPPORT_EMAIL   = "SupportEmail";
-    public static final String DEFAULT_SUPPORT_EMAIL_ADDRESS   = "SupportEmail";
+    public static final String DEFAULT_SUPPORT_EMAIL_ADDRESS   = "support@opendap.org";
 
     public static final String REQUEST_ID      = "reqID";
 

--- a/src/opendap/bes/dap2Responders/Dap2IFH.java
+++ b/src/opendap/bes/dap2Responders/Dap2IFH.java
@@ -111,6 +111,9 @@ public class Dap2IFH extends Dap4Responder {
 
         BesApi besApi = getBesApi();
 
+        String supportEmail = besApi.getSupportEmail(requestedResourceId);
+        String mailtoHrefAttributeValue = OPeNDAPException.getSupportMailtoLink(request,200,"n/a",supportEmail);
+
         _log.debug("sendNormativeRepresentation() - Sending {} for dataset: {}",getServiceTitle(),resourceID);
 
         MediaType responseMediaType = getNormativeMediaType();
@@ -158,6 +161,7 @@ public class Dap2IFH extends Dap4Responder {
             transformer.setParameter("docsService", oreq.getDocsServiceLocalID());
             transformer.setParameter("HyraxVersion", Version.getHyraxVersionString());
             transformer.setParameter("JsonLD", jsonLD);
+            transformer.setParameter("supportLink", mailtoHrefAttributeValue);
 
             AuthenticationControls.setLoginParameters(transformer,request);
 

--- a/src/opendap/bes/dap4Responders/DatasetMetadata/HtmlDMR.java
+++ b/src/opendap/bes/dap4Responders/DatasetMetadata/HtmlDMR.java
@@ -101,6 +101,9 @@ public class HtmlDMR extends Dap4Responder {
 
         BesApi besApi = getBesApi();
 
+        String supportEmail = besApi.getSupportEmail(requestedResourceId);
+        String mailtoHrefAttributeValue = OPeNDAPException.getSupportMailtoLink(request,200,"n/a",supportEmail);
+
         log.debug("sendNormativeRepresentation() - Sending {} for dataset: {}",getServiceTitle(),resourceID);
 
         MediaType responseMediaType =  getNormativeMediaType();
@@ -145,6 +148,7 @@ public class HtmlDMR extends Dap4Responder {
             transformer.setParameter("docsService", oreq.getDocsServiceLocalID());
             transformer.setParameter("HyraxVersion", Version.getHyraxVersionString());
             transformer.setParameter("JsonLD", getDatasetJsonLD(collectionUrl,dmr));
+            transformer.setParameter("supportLink", mailtoHrefAttributeValue);
 
             AuthenticationControls.setLoginParameters(transformer,request);
 

--- a/src/opendap/coreServlet/OPeNDAPException.java
+++ b/src/opendap/coreServlet/OPeNDAPException.java
@@ -589,7 +589,12 @@ public class OPeNDAPException extends Exception {
     public static String getSupportMailtoLink(HttpServletRequest request, int http_status, String errorMessage, String adminEmail){
 
         StringBuilder sb = new StringBuilder();
-        sb.append("mailto:").append(adminEmail).append("?subject=Hyrax Error ").append(http_status);
+        if(http_status!=200){
+            sb.append("mailto:").append(adminEmail).append("?subject=Hyrax Error ").append(http_status);
+        }
+        else {
+            sb.append("mailto:").append(adminEmail).append("?subject=Hyrax Usage Question");
+        }
         sb.append("&body=");
         sb.append("%0A");
         sb.append("%0A");
@@ -604,7 +609,12 @@ public class OPeNDAPException extends Exception {
         sb.append("# Thanks,%0A");
         sb.append("# OPeNDAP Support.%0A");
         sb.append("# %0A");
-        sb.append("# -- -- -- hyrax error info, please include -- -- --%0A");
+        if(http_status !=200) {
+            sb.append("# -- -- -- hyrax error info, please include -- -- --%0A");
+        }
+        else {
+            sb.append("# -- -- -- hyrax location info, please include -- -- --%0A");
+        }
         sb.append("# %0A");
         sb.append("# request_url: ").append(request.getRequestURL().toString()).append("%0A");
         sb.append("# protocol: ").append(request.getProtocol()).append("%0A");
@@ -614,13 +624,16 @@ public class OPeNDAPException extends Exception {
 
         sb.append("# query_string: ");
         String queryString = request.getQueryString();
-        if(queryString!=null && !queryString.isEmpty())
+        if(queryString!=null && !queryString.isEmpty()){
             sb.append(queryString).append("%0A");
-        else
-            sb.append("n/a");
-
+        }
+        else {
+            sb.append("n/a%0A");
+        }
         sb.append("# status: ").append(http_status).append("%0A");
-        sb.append("# message: ").append(errorMessage).append("%0A");
+        if(http_status !=200) {
+            sb.append("# message: ").append(errorMessage).append("%0A");
+        }
         sb.append("# %0A");
         sb.append("# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --%0A");
         return Encode.forHtmlAttribute(sb.toString());


### PR DESCRIPTION
Added support email links to IFH pages and HTML catalog pages. 

Modified the OPeNDAPException.getSupportMailtoLink() to produce mailto
links so that email text for errors is different than for simple
questions about the service.

You can see examples of each change in the following links:

- Catalog HTML Page: http://balto.opendap.org/opendap/data/nc/
- DAP2 IFH: http://balto.opendap.org/opendap/data/nc/fnoc1.nc.html
- DAP4 IFH: http://balto.opendap.org/opendap/data/nc/fnoc1.nc.dmr.html
