### PR TITLE
Respponse logging 2

### DIFF
--- a/resources/hyrax/WEB-INF/logback-test.xml
+++ b/resources/hyrax/WEB-INF/logback-test.xml
@@ -233,10 +233,48 @@
     <logger name="HyraxAccess" level="info">
         <appender-ref ref="HyraxAccessLog"/>
     </logger>
+    <logger name="HyraxLastModifiedAccess" level="info">
+        <appender-ref ref="HyraxAccessLog"/>
+    </logger>
     <logger name="DocsAccess" level="info">
         <appender-ref ref="HyraxAccessLog"/>
     </logger>
     <logger name="SiteMapAccess" level="info">
+        <appender-ref ref="HyraxAccessLog"/>
+    </logger>
+
+    <logger name="PDPServiceAccess" level="info">
+        <appender-ref ref="HyraxAccessLog"/>
+    </logger>
+    <logger name="PDPServiceLastModifiedAccess" level="info">
+        <appender-ref ref="HyraxAccessLog"/>
+    </logger>
+
+    <logger name="HyraxGatewayAccess" level="info">
+        <appender-ref ref="HyraxAccessLog"/>
+    </logger>
+    <logger name="HyraxGatewayLastModifiedAccess" level="info">
+        <appender-ref ref="HyraxAccessLog"/>
+    </logger>
+
+    <logger name="HyraxAdmindAccess" level="info">
+        <appender-ref ref="HyraxAccessLog"/>
+    </logger>
+    <logger name="HyraxAdminLastModifiedAccess" level="info">
+        <appender-ref ref="HyraxAccessLog"/>
+    </logger>
+
+    <logger name="S3ServiceAccess" level="info">
+        <appender-ref ref="HyraxAccessLog"/>
+    </logger>
+    <logger name="S3ServiceLastModifiedAccess" level="info">
+        <appender-ref ref="HyraxAccessLog"/>
+    </logger>
+
+    <logger name="WCSAccess" level="info">
+        <appender-ref ref="HyraxAccessLog"/>
+    </logger>
+    <logger name="WCSLastModifiedAccess" level="info">
         <appender-ref ref="HyraxAccessLog"/>
     </logger>
 

--- a/resources/hyrax/WEB-INF/logback.xml
+++ b/resources/hyrax/WEB-INF/logback.xml
@@ -109,10 +109,22 @@
     <logger name="DocsAccess" level="info">
         <appender-ref ref="HyraxAccessLog"/>
     </logger>
+
+<!--
+    <logger name="HyraxLastModifiedAccess" level="info">
+        <appender-ref ref="HyraxAccessLog"/>
+    </logger>
     <logger name="SiteMapAccess" level="info">
         <appender-ref ref="HyraxAccessLog"/>
     </logger>
 
+    <logger name="PDPServiceAccess" level="info">
+        <appender-ref ref="HyraxAccessLog"/>
+    </logger>
+    <logger name="PDPServiceLastModifiedAccess" level="info">
+        <appender-ref ref="HyraxAccessLog"/>
+    </logger>
+-->
     <!-- logger name="BesCommandLog" level="info">
         <appender-ref ref="BESCommandLogAppender"/>
     </logger -->

--- a/src/opendap/auth/PDPService.java
+++ b/src/opendap/auth/PDPService.java
@@ -52,7 +52,6 @@ import java.util.concurrent.locks.ReentrantLock;
 public class PDPService extends HttpServlet {
 
     private static final Logger LOG = LoggerFactory.getLogger(PDPService.class);
-    private static final String SERVICE_LOG_ID = "PDP_SERVICE_ACCESS";
     private static final ReentrantLock CONFIG_LOCK = new ReentrantLock();
 
     private static final AtomicInteger REQ_NUMBER = new AtomicInteger(0);
@@ -122,11 +121,11 @@ public class PDPService extends HttpServlet {
         try {
             RequestCache.openThreadCache();
             long reqno = REQ_NUMBER.incrementAndGet();
-            LogUtil.logServerAccessStart(req, SERVICE_LOG_ID, "LastModified", Long.toString(reqno));
+            LogUtil.logServerAccessStart(req, LogUtil.PDP_SERVICE_LAST_MODIFIED_LOG_ID, "LastModified", Long.toString(reqno));
             return new Date().getTime();
 
         } finally {
-            LogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, SERVICE_LOG_ID);
+            LogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, LogUtil.PDP_SERVICE_LAST_MODIFIED_LOG_ID);
         }
     }
 
@@ -164,7 +163,7 @@ public class PDPService extends HttpServlet {
         String msg = "";
         int status = HttpServletResponse.SC_FORBIDDEN;
 
-        LogUtil.logServerAccessStart(request, SERVICE_LOG_ID, request.getMethod(), Integer.toString(REQ_NUMBER.incrementAndGet()));
+        LogUtil.logServerAccessStart(request, LogUtil.PDP_SERVICE_ACCESS_LOG_ID, request.getMethod(), Integer.toString(REQ_NUMBER.incrementAndGet()));
         try {
             if (!redirect(request, response)) {
 
@@ -225,7 +224,7 @@ public class PDPService extends HttpServlet {
             }
         }
         finally {
-            LogUtil.logServerAccessEnd(status, SERVICE_LOG_ID);
+            LogUtil.logServerAccessEnd(status, LogUtil.PDP_SERVICE_ACCESS_LOG_ID);
             RequestCache.closeThreadCache();
         }
     }

--- a/src/opendap/bes/BESThreddsDispatchHandler.java
+++ b/src/opendap/bes/BESThreddsDispatchHandler.java
@@ -52,10 +52,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Vector;
+import java.util.*;
 import java.util.regex.Pattern;
 
 /**
@@ -338,11 +335,10 @@ public class BESThreddsDispatchHandler implements DispatchHandler {
     public long getLastModified(HttpServletRequest req){
         String name = ReqInfo.getLocalUrl(req);
 
-        _log.debug("getLastModified(): Tomcat requesting getlastModified() for " +
-                "collection: " + name );
-        _log.debug("getLastModified(): Returning: -1" );
+        _log.debug("getLastModified(): Tomcat requesting getlastModified() for collection: {}", name );
+        _log.debug("getLastModified(): Returning current date/time" );
 
-        return -1;
+        return new Date().getTime();
     }
 
 

--- a/src/opendap/bes/BesDapDispatcher.java
+++ b/src/opendap/bes/BesDapDispatcher.java
@@ -396,14 +396,10 @@ public class BesDapDispatcher implements DispatchHandler {
 
     public long getLastModified(HttpServletRequest req) {
 
-
-
-        String relativeUrl = ReqInfo.getLocalUrl(req);
-
+         String relativeUrl = ReqInfo.getLocalUrl(req);
 
         if(!_initialized)
-            return -1;
-
+            return new Date().getTime();
 
         for (HttpResponder r : _responders) {
             if (r.matches(relativeUrl)) {
@@ -418,14 +414,14 @@ public class BesDapDispatcher implements DispatchHandler {
 
                 } catch (Exception e) {
                     _log.debug("getLastModified(): Returning: -1");
-                    return -1;
+                    return new Date().getTime();
                 }
 
             }
 
         }
 
-        return -1;
+        return new Date().getTime();
 
 
     }

--- a/src/opendap/bes/BesDapResponder.java
+++ b/src/opendap/bes/BesDapResponder.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.Date;
 
 /**
  * Created by IntelliJ IDEA.
@@ -72,7 +73,7 @@ public abstract class BesDapResponder extends DapResponder {
         String relativeUrl = ReqInfo.getLocalUrl(request);
         String dataSource = getBesApi().getBesDataSourceID(relativeUrl, false);
         if(dataSource == null){
-            return -1;
+            return new Date().getTime();
         }
 
         ResourceInfo ri = getResourceInfo(dataSource);

--- a/src/opendap/bes/DirectoryDispatchHandler.java
+++ b/src/opendap/bes/DirectoryDispatchHandler.java
@@ -125,7 +125,7 @@ public class DirectoryDispatchHandler implements DispatchHandler {
         }
         catch (Exception e) {
             log.debug("getLastModified():  Returning: -1");
-            return -1;
+            return new Date().getTime();
         }
     }
 

--- a/src/opendap/bes/FileDispatchHandler.java
+++ b/src/opendap/bes/FileDispatchHandler.java
@@ -92,9 +92,7 @@ public class FileDispatchHandler implements DispatchHandler {
     public long getLastModified(HttpServletRequest req) {
 
         String name = ReqInfo.getLocalUrl(req);
-
         log.debug("getLastModified(): Tomcat requesting getlastModified() for collection: " + name );
-
 
         try {
             ResourceInfo dsi = new BESResource(name,_besApi);
@@ -103,18 +101,16 @@ public class FileDispatchHandler implements DispatchHandler {
             return dsi.lastModified();
         }
         catch (Exception e) {
-            log.debug("getLastModified(): Returning: -1");
-            return -1;
+            long now = new Date().getTime();
+            log.debug("getLastModified(): Returning current date/time: {}",now);
+            return now;
         }
-
-
     }
 
 
 
     public void destroy() {
         log.info("Destroy complete.");
-
     }
 
     /**

--- a/src/opendap/bes/VersionDispatchHandler.java
+++ b/src/opendap/bes/VersionDispatchHandler.java
@@ -40,6 +40,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.PrintStream;
+import java.util.Date;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -107,7 +108,7 @@ public class VersionDispatchHandler implements DispatchHandler {
     }
 
     public long getLastModified(HttpServletRequest req) {
-        return -1;
+        return new Date().getTime();
     }
 
 

--- a/src/opendap/bes/dap2Responders/DatasetInfoHtmlPage.java
+++ b/src/opendap/bes/dap2Responders/DatasetInfoHtmlPage.java
@@ -32,11 +32,12 @@ import opendap.coreServlet.OPeNDAPException;
 import opendap.coreServlet.ReqInfo;
 import opendap.coreServlet.RequestCache;
 import opendap.http.mediaTypes.TextHtml;
+import opendap.logging.LogUtil;
 import org.slf4j.Logger;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.OutputStream;
+import java.io.DataOutputStream;
 
 
 
@@ -56,6 +57,7 @@ public class DatasetInfoHtmlPage extends Dap4Responder {
     public DatasetInfoHtmlPage(String sysPath, BesApi besApi) {
         this(sysPath,null, _defaultRequestSuffix,besApi);
     }
+
     public DatasetInfoHtmlPage(String sysPath, String pathPrefix, BesApi besApi) {
         this(sysPath,pathPrefix, _defaultRequestSuffix,besApi);
     }
@@ -101,10 +103,11 @@ public class DatasetInfoHtmlPage extends Dap4Responder {
         response.setStatus(HttpServletResponse.SC_OK);
         String xdap_accept = request.getHeader("XDAP-Accept");
 
-        OutputStream os = response.getOutputStream();
+        DataOutputStream os = new DataOutputStream(response.getOutputStream());
         besApi.writeDap2HtmlInfoPage(resourceID, xdap_accept, os);
         os.flush();
-        log.info("Sent DAP Info page.");
+        LogUtil.setResponseSize(os.size());
+        log.debug("Sent {} size:{}",getServiceTitle(),os.size());
     }
 
 }

--- a/src/opendap/bes/dap4Responders/Dap4Responder.java
+++ b/src/opendap/bes/dap4Responders/Dap4Responder.java
@@ -355,7 +355,6 @@ public abstract class Dap4Responder extends BesDapResponder  {
     @Override
     public long getLastModified(HttpServletRequest request) throws Exception {
 
-
         String relativeUrl = ReqInfo.getLocalUrl(request);
         String dataSource = getResourceId(relativeUrl,true);
 
@@ -363,7 +362,6 @@ public abstract class Dap4Responder extends BesDapResponder  {
 
         ResourceInfo ri = getResourceInfo(dataSource);
         return ri.lastModified();
-
     }
 
 

--- a/src/opendap/coreServlet/BotBlocker.java
+++ b/src/opendap/coreServlet/BotBlocker.java
@@ -32,6 +32,7 @@ import org.jdom.Element;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Vector;
 import java.util.regex.Pattern;
@@ -249,7 +250,7 @@ public class BotBlocker implements DispatchHandler {
      * @see javax.servlet.http.HttpServlet
      */
     public long getLastModified(HttpServletRequest req) {
-        return -1;
+        return new Date().getTime();
 
     }
 

--- a/src/opendap/coreServlet/DispatchServlet.java
+++ b/src/opendap/coreServlet/DispatchServlet.java
@@ -573,7 +573,7 @@ public class DispatchServlet extends HttpServlet {
         RequestCache.openThreadCache();
 
         long reqno = reqNumber.incrementAndGet();
-        LogUtil.logServerAccessStart(req, LogUtil.HYRAX_ACCESS_LOG_ID, "LastModified", Long.toString(reqno));
+        LogUtil.logServerAccessStart(req, LogUtil.HYRAX_LAST_MODIFIED_ACCESS_LOG_ID, "LastModified", Long.toString(reqno));
 
         long lmt = new Date().getTime();
 
@@ -594,7 +594,7 @@ public class DispatchServlet extends HttpServlet {
             log.error("Caught: {}  Message: {} ",e.getClass().getName(), e.getMessage());
             lmt = new Date().getTime();
         } finally {
-            LogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, LogUtil.HYRAX_ACCESS_LOG_ID);
+            LogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, LogUtil.HYRAX_LAST_MODIFIED_ACCESS_LOG_ID);
             Timer.stop(timedProcedure);
         }
         return lmt;

--- a/src/opendap/coreServlet/NoPostHandler.java
+++ b/src/opendap/coreServlet/NoPostHandler.java
@@ -33,6 +33,7 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Date;
 
 /**
  * Created by IntelliJ IDEA.
@@ -62,7 +63,7 @@ public class NoPostHandler implements DispatchHandler {
     }
 
     public long getLastModified(HttpServletRequest req) {
-        return -1;  // punt...
+        return new Date().getTime();  // Return current date/time
     }
 
     public void destroy() {

--- a/src/opendap/gateway/DispatchServlet.java
+++ b/src/opendap/gateway/DispatchServlet.java
@@ -59,7 +59,6 @@ public class DispatchServlet extends HttpServlet {
     private final AtomicBoolean isInitialized = new AtomicBoolean(false);
     private static final AtomicInteger reqNumber = new AtomicInteger(0);
 
-    private static final String GATEWAY_ACCESS_LOG_ID = "HYRAX_GATEWAY_ACCESS";
 
     private static Element config;
     private static DispatchHandler gatewayDispatchHandler;
@@ -154,7 +153,7 @@ public class DispatchServlet extends HttpServlet {
         RequestCache.openThreadCache();
 
         long reqno = reqNumber.incrementAndGet();
-        LogUtil.logServerAccessStart(req, GATEWAY_ACCESS_LOG_ID, "LastModified", Long.toString(reqno));
+        LogUtil.logServerAccessStart(req, LogUtil.GATEWAY_ACCESS_LAST_MODIFIED_LOG_ID, "LastModified", Long.toString(reqno));
         try {
             if (ReqInfo.isServiceOnlyRequest(req))
                 return new Date().getTime();
@@ -162,7 +161,7 @@ public class DispatchServlet extends HttpServlet {
             return gatewayDispatchHandler.getLastModified(req);
         }
         finally {
-            LogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, GATEWAY_ACCESS_LOG_ID);
+            LogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, LogUtil.GATEWAY_ACCESS_LAST_MODIFIED_LOG_ID);
         }
     }
 
@@ -189,7 +188,7 @@ public class DispatchServlet extends HttpServlet {
 
         int request_status = HttpServletResponse.SC_OK;
         try {
-            LogUtil.logServerAccessStart(request, GATEWAY_ACCESS_LOG_ID, "HTTP-GET", Integer.toString(reqNumber.incrementAndGet()));
+            LogUtil.logServerAccessStart(request, LogUtil.GATEWAY_ACCESS_LOG_ID, "HTTP-GET", Integer.toString(reqNumber.incrementAndGet()));
             if (!redirect(request, response)) {
 
                 if(!gatewayDispatchHandler.requestDispatch(request,response,true)){
@@ -207,7 +206,7 @@ public class DispatchServlet extends HttpServlet {
                 log.error("BAD THINGS HAPPENED!", t2);
             }
         } finally {
-            LogUtil.logServerAccessEnd(request_status, GATEWAY_ACCESS_LOG_ID);
+            LogUtil.logServerAccessEnd(request_status, LogUtil.GATEWAY_ACCESS_LOG_ID);
             RequestCache.closeThreadCache();
         }
     }

--- a/src/opendap/gateway/GatewayForm.java
+++ b/src/opendap/gateway/GatewayForm.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Date;
 
 /**
  * Created by IntelliJ IDEA.
@@ -74,7 +75,7 @@ public class GatewayForm extends HttpResponder {
 
     @Override
     public long getLastModified(HttpServletRequest request) throws Exception {
-        return 0;  //To change body of implemented methods use File | Settings | File Templates.
+        return new Date().getTime();
     }
 
     public void respondToHttpGetRequest(HttpServletRequest request, HttpServletResponse response) throws Exception {

--- a/src/opendap/hai/BesControlApi.java
+++ b/src/opendap/hai/BesControlApi.java
@@ -46,10 +46,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.TreeMap;
+import java.util.*;
 
 public class BesControlApi extends HttpResponder {
 
@@ -91,7 +88,7 @@ public class BesControlApi extends HttpResponder {
 
     @Override
     public long getLastModified(HttpServletRequest request) throws Exception {
-        return 0;  //To change body of implemented methods use File | Settings | File Templates.
+        return new Date().getTime();  //To change body of implemented methods use File | Settings | File Templates.
     }
 
     public void respondToHttpGetRequest(HttpServletRequest request, HttpServletResponse response) throws Exception {

--- a/src/opendap/hai/DispatchServlet.java
+++ b/src/opendap/hai/DispatchServlet.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.Date;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
@@ -160,18 +161,6 @@ public class DispatchServlet extends opendap.coreServlet.DispatchServlet {
     }
 
 
-    /*
-    public long getLastModified(HttpServletRequest req) {
-
-        long lmt;
-        lmt = -1;
-        return lmt;
-
-
-    }
-    */
-
-
     /**
      * Gets the last modified date of the requested resource. Because the data handler is really
      * the only entity capable of determining the last modified date the job is passed  through to it.
@@ -181,27 +170,15 @@ public class DispatchServlet extends opendap.coreServlet.DispatchServlet {
      *         since midnight January 1, 1970 GMT
      */
     protected long getLastModified(HttpServletRequest req) {
-
         RequestCache.openThreadCache();
-
         long reqno = reqNumber.incrementAndGet();
-        LogUtil.logServerAccessStart(req, "ADMIN_SERVICE_ACCESS", "LastModified", Long.toString(reqno));
-
-        if (ReqInfo.isServiceOnlyRequest(req))
-            return -1;
-
-
+        LogUtil.logServerAccessStart(req, LogUtil.ADMIN_ACCESS_LAST_MODIFIED_LOG_ID, "LastModified", Long.toString(reqno));
         try {
-            return -1;
-
-        } catch (Exception e) {
-            return -1;
-        } finally {
-            LogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, "ADMIN_SERVICE_ACCESS");
-
+            return new Date().getTime();
         }
-
-
+        finally {
+            LogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, LogUtil.ADMIN_ACCESS_LAST_MODIFIED_LOG_ID);
+        }
     }
 
 
@@ -228,7 +205,7 @@ public class DispatchServlet extends opendap.coreServlet.DispatchServlet {
 
         try {
 
-            LogUtil.logServerAccessStart(request, "ADMIN_SERVICE_ACCESS", "HTTP-GET", Integer.toString(reqNumber.incrementAndGet()));
+            LogUtil.logServerAccessStart(request, LogUtil.ADMIN_ACCESS_LOG_ID, "HTTP-GET", Integer.toString(reqNumber.incrementAndGet()));
 
             if (!redirect(request, response)) {
 
@@ -268,7 +245,7 @@ public class DispatchServlet extends opendap.coreServlet.DispatchServlet {
                 log.error("BAD THINGS HAPPENED!", t2);
             }
         } finally {
-            LogUtil.logServerAccessEnd(request_status, "ADMIN_SERVICE_ACCESS");
+            LogUtil.logServerAccessEnd(request_status, LogUtil.ADMIN_ACCESS_LOG_ID);
             RequestCache.closeThreadCache();
         }
     }
@@ -280,7 +257,7 @@ public class DispatchServlet extends opendap.coreServlet.DispatchServlet {
 
         try {
 
-            LogUtil.logServerAccessStart(request, "ADMIN_SERVICE_ACCESS", "HTTP-POST", Integer.toString(reqNumber.incrementAndGet()));
+            LogUtil.logServerAccessStart(request, LogUtil.ADMIN_ACCESS_LOG_ID, "HTTP-POST", Integer.toString(reqNumber.incrementAndGet()));
 
             if (!redirect(request, response)) {
 
@@ -316,7 +293,7 @@ public class DispatchServlet extends opendap.coreServlet.DispatchServlet {
                 log.error("BAD THINGS HAPPENED!", t2);
             }
         } finally {
-            LogUtil.logServerAccessEnd(request_status, "ADMIN_SERVICE_ACCESS");
+            LogUtil.logServerAccessEnd(request_status, LogUtil.ADMIN_ACCESS_LOG_ID);
             RequestCache.closeThreadCache();
         }
     }

--- a/src/opendap/hai/OlfsControlApi.java
+++ b/src/opendap/hai/OlfsControlApi.java
@@ -117,7 +117,7 @@ public class OlfsControlApi extends HttpResponder {
 
     @Override
     public long getLastModified(HttpServletRequest request) throws Exception {
-        return 0;  //To change body of implemented methods use File | Settings | File Templates.
+        return new Date().getTime();
     }
 
     public void respondToHttpGetRequest(HttpServletRequest request, HttpServletResponse response) throws Exception {

--- a/src/opendap/logging/LogUtil.java
+++ b/src/opendap/logging/LogUtil.java
@@ -54,9 +54,27 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class LogUtil {
 
-    public static final String DOCS_ACCESS_LOG_ID = "DocsAccess";
-    public static final String SITEMAP_ACCESS_LOG_ID = "SiteMapAccess";
     public static final String HYRAX_ACCESS_LOG_ID = "HyraxAccess";
+    public static final String HYRAX_LAST_MODIFIED_ACCESS_LOG_ID = "HyraxLastModifiedAccess";
+
+    public static final String DOCS_ACCESS_LOG_ID = "DocsAccess";
+
+    public static final String SITEMAP_ACCESS_LOG_ID = "SiteMapAccess";
+
+    public static final String PDP_SERVICE_ACCESS_LOG_ID = "PDPServiceAccess";
+    public static final String PDP_SERVICE_LAST_MODIFIED_LOG_ID = "PDPServiceLastModifiedAccess";
+
+    public static final String GATEWAY_ACCESS_LOG_ID = "HyraxGatewayAccess";
+    public static final String GATEWAY_ACCESS_LAST_MODIFIED_LOG_ID = "HyraxGatewayLastModifiedAccess";
+
+    public static final String ADMIN_ACCESS_LOG_ID = "HyraxAdminAccess";
+    public static final String ADMIN_ACCESS_LAST_MODIFIED_LOG_ID = "HyraxAdminLastModifiedAccess";
+
+    public static final String S3_SERVICE_ACCESS_LOG_ID = "S3ServiceAccess";
+    public static final String S3_SERVICE_LAST_MODIFIED_LOG_ID = "S3ServiceLastModifiedAccess";
+
+    public static final String WCS_ACCESS_LOG_ID = "WCSAccess";
+    public static final String WCS_LAST_MODIFIED_ACCESS_LOG_ID = "WCSLastModifiedAccess";
 
     private static final String ID_KEY = "ID";
     private static final String SOURCE_KEY = "SOURCE";

--- a/src/opendap/nciso/IsoDispatchHandler.java
+++ b/src/opendap/nciso/IsoDispatchHandler.java
@@ -114,18 +114,18 @@ public class IsoDispatchHandler implements opendap.coreServlet.DispatchHandler {
 
         String name = ReqInfo.getLocalUrl(req);
 
-        log.debug("getLastModified(): Tomcat requesting getlastModified() for collection: " + name );
+        log.debug("Tomcat requesting LMT for collection: {}", name );
 
 
         try {
             ResourceInfo dsi = new BESResource(name, _besApi);
-            log.debug("getLastModified(): Returning: " + new Date(dsi.lastModified()));
+            log.debug("Returning: {}", new Date(dsi.lastModified()));
 
             return dsi.lastModified();
         }
         catch (Exception e) {
-            log.debug("getLastModified(): Returning: -1");
-            return -1;
+            log.debug("Returning current date/time.");
+            return new Date().getTime();
         }
 
 

--- a/src/opendap/nciso/RubricDispatchHandler.java
+++ b/src/opendap/nciso/RubricDispatchHandler.java
@@ -119,18 +119,18 @@ public class RubricDispatchHandler implements opendap.coreServlet.DispatchHandle
 
         String name = ReqInfo.getLocalUrl(req);
 
-        log.debug("getLastModified(): Tomcat requesting getlastModified() for collection: " + name );
+        log.debug("Locating LMT for collection: {}", name );
 
 
         try {
             ResourceInfo dsi = new BESResource(name,_besApi);
-            log.debug("getLastModified(): Returning: " + new Date(dsi.lastModified()));
+            log.debug("Returning: {}" + new Date(dsi.lastModified()));
 
             return dsi.lastModified();
         }
         catch (Exception e) {
-            log.debug("getLastModified(): Returning: -1");
-            return -1;
+            log.debug("Returning current date/time.");
+            return new Date().getTime();
         }
 
 

--- a/src/opendap/ncml/NcmlFileDispatcher.java
+++ b/src/opendap/ncml/NcmlFileDispatcher.java
@@ -121,18 +121,18 @@ public class NcmlFileDispatcher implements opendap.coreServlet.DispatchHandler {
 
         String name = ReqInfo.getLocalUrl(req);
 
-        log.debug("getLastModified(): Tomcat requesting getlastModified() for collection: " + name );
+        log.debug("Locating LMT for collection: {}", name );
 
 
         try {
             ResourceInfo dsi = new BESResource(name, _besApi);
-            log.debug("getLastModified(): Returning: " + new Date(dsi.lastModified()));
+            log.debug("Returning: {}", new Date(dsi.lastModified()));
 
             return dsi.lastModified();
         }
         catch (Exception e) {
-            log.debug("getLastModified(): Returning: -1");
-            return -1;
+            log.debug("Returning current date/time.");
+            return new Date().getTime();
         }
 
 

--- a/src/opendap/ncml/NcmlManager.java
+++ b/src/opendap/ncml/NcmlManager.java
@@ -48,6 +48,7 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Vector;
@@ -211,11 +212,8 @@ public class NcmlManager {
     public static long getLastModified(String dapAccessID){
 
         Long lmt = _ncmlDatasetsLastModifiedTimes.get(dapAccessID);
-
-
         if(lmt==null)
-            lmt = (long) -1;
-
+            lmt = new Date().getTime();
 
         return lmt;
     }

--- a/src/opendap/noaa_s3/RemoteResource.java
+++ b/src/opendap/noaa_s3/RemoteResource.java
@@ -205,20 +205,20 @@ public class RemoteResource {
         if (_lastModified == 0) {
             String lmt_string = getHeaderValue("last-modified");
 
-            if (lmt_string == null)
-                _lastModified = -1;
-
+            if (lmt_string == null) {
+                _lastModified = new Date().getTime();
+            }
             else {
                 try {
                     SimpleDateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz");
                     Date d = format.parse(lmt_string);
                     _lastModified = d.getTime();
                 } catch (ParseException e) {
-                    _lastModified = -1;
+                    _lastModified = new Date().getTime();
                 }
             }
         }
-        log.debug("getLastModified() - {}", _lastModified);
+        log.debug("Returning: {}", _lastModified);
 
         return _lastModified;
     }

--- a/src/opendap/noaa_s3/S3BesApi.java
+++ b/src/opendap/noaa_s3/S3BesApi.java
@@ -131,14 +131,14 @@ public class S3BesApi extends BesGatewayApi {
 
 
 
-        log.debug("getLastModified() - remoteResourceUrl: "+remoteResourceUrl);
+        log.debug("remoteResourceUrl: {}", remoteResourceUrl);
 
 
         // Try to get it from the request cache.
         String lmt_cache_key = remoteResourceUrl+"_last-modified";
         Long lmt =  (Long) RequestCache.get(lmt_cache_key);
         if(lmt!=null){
-            log.debug("getLastModified() - using cached lmt: {}",lmt);
+            log.debug("Using cached lmt: {}",lmt);
             return lmt;
         }
 
@@ -156,7 +156,7 @@ public class S3BesApi extends BesGatewayApi {
 
                 if (statusCode != HttpStatus.SC_OK) {
                     log.error("getLastModified() - Unable to HEAD s3 object: " + remoteResourceUrl);
-                    lastModifiedTime = -1;
+                    lastModifiedTime = new Date().getTime();
                 }
                 else {
                     log.debug("getLastModified(): Executed HTTP HEAD for "+remoteResourceUrl);
@@ -164,7 +164,7 @@ public class S3BesApi extends BesGatewayApi {
                     Header lastModifiedHeader = headReq.getResponseHeader("Last-Modified");
 
                     if(lastModifiedHeader==null){
-                     lastModifiedTime =  -1;
+                     lastModifiedTime =  new Date().getTime();
                     }
                     else {
                         String lmtString = lastModifiedHeader.getValue();
@@ -176,12 +176,12 @@ public class S3BesApi extends BesGatewayApi {
 
             } catch (Exception e) {
                 log.error("Unable to HEAD the s3 resource: {} Error Msg: {}", remoteResourceUrl, e.getMessage());
-                lastModifiedTime = -1;
+                lastModifiedTime = new Date().getTime();
             }
 
         } catch (Exception e) {
             log.debug("getLastModified(): Returning: -1");
-            lastModifiedTime =  -1;
+            lastModifiedTime =  new Date().getTime();
         }
 
         RequestCache.put(lmt_cache_key, lastModifiedTime);

--- a/src/opendap/noaa_s3/S3CatalogServlet.java
+++ b/src/opendap/noaa_s3/S3CatalogServlet.java
@@ -343,7 +343,7 @@ public class S3CatalogServlet extends HttpServlet {
         Procedure tKey = Timer.start();
         int status = HttpServletResponse.SC_OK;
         try {
-            LogUtil.logServerAccessStart(request, "S3_ACCESS", "HTTP-GET", Integer.toString(_reqNumber.incrementAndGet()));
+            LogUtil.logServerAccessStart(request, LogUtil.S3_SERVICE_ACCESS_LOG_ID, "HTTP-GET", Integer.toString(_reqNumber.incrementAndGet()));
             if (!redirectToCatalog(request, response)) {  // Do we send the catalog redirect?
                 String requestURI = request.getRequestURI();
                 String catalogServiceContext = S3CatalogManager.theManager().getCatalogServiceContext();
@@ -379,32 +379,37 @@ public class S3CatalogServlet extends HttpServlet {
             }
         } finally {
             RequestCache.closeThreadCache();
-            LogUtil.logServerAccessEnd(status, "S3_ACCESS");
+            LogUtil.logServerAccessEnd(status, LogUtil.S3_SERVICE_ACCESS_LOG_ID);
             Timer.stop(tKey);
         }
     }
 
     public long getLastModified(HttpServletRequest req) {
 
+
         Procedure tKey = Timer.start();
         RequestCache.openThreadCache();
         long reqno = _reqNumber.incrementAndGet();
         long lmt = new Date().getTime();
 
-        String requestURI = req.getRequestURI();
-        String catalogServiceContext = S3CatalogManager.theManager().getCatalogServiceContext();
-        String dapServiceContext = S3CatalogManager.theManager().getDapServiceContext();
+        LogUtil.logServerAccessStart(req, LogUtil.S3_SERVICE_LAST_MODIFIED_LOG_ID, "LastModified", Long.toString(reqno));
+        try {
+            String requestURI = req.getRequestURI();
+            String catalogServiceContext = S3CatalogManager.theManager().getCatalogServiceContext();
+            String dapServiceContext = S3CatalogManager.theManager().getDapServiceContext();
 
-        if(requestURI.startsWith(catalogServiceContext)){
-            LogUtil.logServerAccessStart(req, "S3_CATALOG_ACCESS", "LastModified", Long.toString(reqno));
-            lmt = getCatalogLastModified(req);
+
+            if (requestURI.startsWith(catalogServiceContext)) {
+                lmt = getCatalogLastModified(req);
+            } else if (requestURI.startsWith(dapServiceContext)) {
+                lmt = _s3DapDispatcher.getLastModified(req);
+            }
+            return lmt;
         }
-        else if (requestURI.startsWith(dapServiceContext)) {
-            LogUtil.logServerAccessStart(req, "S3_DAP_ACCESS", "LastModified", Long.toString(reqno));
-            lmt = _s3DapDispatcher.getLastModified(req);
+        finally {
+            Timer.stop(tKey);
+            LogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, LogUtil.S3_SERVICE_LAST_MODIFIED_LOG_ID);
         }
-        Timer.stop(tKey);
-        return lmt;
     }
 
 

--- a/src/opendap/noaa_s3/S3DapDispatchHandler.java
+++ b/src/opendap/noaa_s3/S3DapDispatchHandler.java
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Date;
 import java.util.regex.Pattern;
 
 /**
@@ -108,45 +109,33 @@ public class S3DapDispatchHandler extends BesDapDispatcher {
 
         String relativeURL = ReqInfo.getLocalUrl(req);
 
-        log.debug("getLastModified() - relativeURL: {}",relativeURL);
-
-
-        if(false)
-            return -1;
-
-        long lmt = -1;
+        log.debug("relativeURL: {}",relativeURL);
+        long lmt = new Date().getTime();
 
         for (HttpResponder r : getResponders()) {
-            log.debug("Checking responder: "+ r.getClass().getSimpleName()+ " (pathPrefix: "+r.getPathPrefix()+")");
-
+            log.debug("Checking responder: {} (pathPrefix: {})",r.getClass().getSimpleName(), r.getPathPrefix());
 
            if(r instanceof Dap4Responder) {
                Dap4Responder d4r = (Dap4Responder)r;
-
                Pattern suffixPattern = Pattern.compile(d4r.getCombinedRequestSuffixRegex(), Pattern.CASE_INSENSITIVE);
-
 
                if(Util.matchesSuffixPattern(relativeURL, suffixPattern)) {
 
-                   log.info("The relative URL: " + relativeURL + " matches " +
-                           "the pattern: \"" + r.getRequestMatchRegexString() + "\"");
+                   log.info("The relative URL: {}  matches the pattern: \"{}\"",
+                           relativeURL, r.getRequestMatchRegexString());
 
                    String resourceId = d4r.removeRequestSuffixFromString(relativeURL);
-
                    S3IndexedFile s3if = S3CatalogManager.theManager().getIndexedFile(resourceId);
 
                    if(s3if!=null){
                        lmt = s3if.getLastModified();
-                       log.debug("lastModified() - Returning: {}",lmt);
+                       log.debug("Returning: {}",lmt);
                        return lmt;
                    }
-
                }
-
            }
-
         }
-        log.debug("lastModified() - Returning: {}",lmt);
+        log.debug("Returning: {}",lmt);
         return lmt;
     }
 

--- a/src/opendap/threddsHandler/BesCatalog.java
+++ b/src/opendap/threddsHandler/BesCatalog.java
@@ -618,6 +618,6 @@ public class BesCatalog implements Catalog {
 
     @Override
     public long getLastModified() {
-        return -1;
+        return new Date().getTime();
     }
 }

--- a/src/opendap/threddsHandler/CatalogManager.java
+++ b/src/opendap/threddsHandler/CatalogManager.java
@@ -44,6 +44,7 @@ import org.jdom.output.XMLOutputter;
 import org.slf4j.Logger;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
@@ -342,17 +343,15 @@ public class CatalogManager {
 
         Catalog cat;
 
-
         try {
             cat = getCatalog(catalogKey);
             if (cat != null)
                 return cat.getLastModified();
         }
-        catch(Exception e){
-            _log.info("No such catalog: {}",catalogKey);
+        catch (SaxonApiException | BESError e) {
+            _log.info("Failed to retrieve catalog: {}  (msg: {})",catalogKey, e.getMessage());
         }
-
-        return -1;
+        return new Date().getTime();
     }
 
     /**

--- a/src/opendap/threddsHandler/RemoteHttpCatalog.java
+++ b/src/opendap/threddsHandler/RemoteHttpCatalog.java
@@ -207,7 +207,7 @@ public class RemoteHttpCatalog implements Catalog {
         return null;  //To change body of implemented methods use File | Settings | File Templates.
     }
     public long getLastModified() {
-        return -1;  //To change body of implemented methods use File | Settings | File Templates.
+        return new Date().getTime();  //To change body of implemented methods use File | Settings | File Templates.
     }
 
     public String getIngestTransformFilename(){

--- a/src/opendap/threddsHandler/StaticCatalogDispatch.java
+++ b/src/opendap/threddsHandler/StaticCatalogDispatch.java
@@ -857,19 +857,19 @@ public class StaticCatalogDispatch implements DispatchHandler {
         try {
             catalogKey = getCatalogKeyFromRelativeUrl(ReqInfo.getLocalUrl(req));
             if (requestCanBeHandled(req)) {
-                long lm = CatalogManager.getLastModified(catalogKey);
-                _log.debug("lastModified(" + catalogKey + "): " + (lm == -1 ? "unknown" : new Date(lm)));
-                return lm;
+                long lmt = CatalogManager.getLastModified(catalogKey);
+                _log.debug("lastModified({}): {}", new Date(lmt));
+                return lmt;
             }
         }
         catch (Exception e) {
-            _log.error("Failed to get a last modified time for '" + Scrub.urlContent(catalogKey) + "'  msg: " + e.getMessage());
+            _log.error("Failed to get a last modified time for '{}' msg: {}", Scrub.urlContent(catalogKey), e.getMessage());
         }
         finally {
             Timer.stop(timedProc);
         }
 
-        return -1;
+        return new Date().getTime();
     }
 
     public void destroy() {

--- a/src/opendap/viewers/ViewersServlet.java
+++ b/src/opendap/viewers/ViewersServlet.java
@@ -386,7 +386,7 @@ public class ViewersServlet extends HttpServlet {
     public void doGet(HttpServletRequest req, HttpServletResponse resp) {
 
         RequestCache.openThreadCache();
-        LogUtil.logServerAccessStart(req, "WebStartServletAccess", "HTTP-GET", Integer.toString(REQ_NUMBER.incrementAndGet()));
+        LogUtil.logServerAccessStart(req, LogUtil.HYRAX_ACCESS_LOG_ID, "HTTP-GET", Integer.toString(REQ_NUMBER.incrementAndGet()));
         LOG.debug(ServletUtil.showRequest(req, REQ_NUMBER.get()));
 
         Request dapRequest = new Request(this,req);
@@ -430,10 +430,10 @@ public class ViewersServlet extends HttpServlet {
             }
 
             if (applicationID.equals("viewers")) {
-
+                DataOutputStream dos = new DataOutputStream(resp.getOutputStream());
                 resp.setContentType("text/html");
-                sendDatasetPage(getServiceId(),dapRequest.getDocsServiceLocalID(), dapService, besDatasetId, ddx, resp.getOutputStream());
-                
+                sendDatasetPage(getServiceId(),dapRequest.getDocsServiceLocalID(), dapService, besDatasetId, ddx, dos);
+                LogUtil.setResponseSize(dos.size());
             } else {
                 String dataAccessURL = serverURL+dapService+besDatasetId;
 
@@ -450,10 +450,12 @@ public class ViewersServlet extends HttpServlet {
                         resp.setContentType(mType);
 
                     // Get the sink
-                    PrintWriter pw = resp.getWriter();
+                    DataOutputStream dos = new DataOutputStream(resp.getOutputStream());
+                    PrintStream ps = new PrintStream(dos);
 
                     // Send the jnlp to the client.
-                    pw.print(jnlpContent);
+                    ps.print(jnlpContent);
+                    LogUtil.setResponseSize(dos.size());
 
                 } else {
                     String msg = "Unable to locate a Java WebStart handler to respond to: "+Scrub.simpleString(applicationID)+"?"+query;
@@ -481,9 +483,9 @@ public class ViewersServlet extends HttpServlet {
             }
         }
         finally {
-            LogUtil.logServerAccessEnd(request_status, "WebStartServletAccess");
+            LogUtil.logServerAccessEnd(request_status, LogUtil.HYRAX_ACCESS_LOG_ID);
             RequestCache.closeThreadCache();
-             this.destroy();
+            // this.destroy(); // I commented this out because: WTF? Why? - ndp 03/05/2019
         }
     }
 

--- a/src/opendap/w10n/W10nServlet.java
+++ b/src/opendap/w10n/W10nServlet.java
@@ -53,7 +53,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class W10nServlet extends HttpServlet   {
 
-    private static final String SERVICE_LOG_ID = "W10N-ACCESS";
     private static final Logger LOG = LoggerFactory.getLogger(W10nServlet.class);
     private static final W10nResponder W10N_RESPONDER = new W10nResponder();
 
@@ -91,7 +90,7 @@ public class W10nServlet extends HttpServlet   {
     protected long getLastModified(HttpServletRequest req) {
         RequestCache.openThreadCache();
         long reqno = _reqNumber.incrementAndGet();
-        LogUtil.logServerAccessStart(req, SERVICE_LOG_ID, "LastModified", Long.toString(reqno));
+        LogUtil.logServerAccessStart(req, LogUtil.HYRAX_LAST_MODIFIED_ACCESS_LOG_ID, "LastModified", Long.toString(reqno));
         long lmt = new Date().getTime();
         Procedure timedProcedure = Timer.start();
         try {
@@ -102,7 +101,7 @@ public class W10nServlet extends HttpServlet   {
         } catch (Exception e) {
             LOG.error("Caught: {}  Message: {} ", e.getClass().getName(), e.getMessage());
         } finally {
-            LogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, SERVICE_LOG_ID);
+            LogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, LogUtil.HYRAX_LAST_MODIFIED_ACCESS_LOG_ID);
             Timer.stop(timedProcedure);
         }
         return lmt;
@@ -123,7 +122,7 @@ public class W10nServlet extends HttpServlet   {
                 RequestCache.openThreadCache();
 
                 int reqno = _reqNumber.incrementAndGet();
-                LogUtil.logServerAccessStart(request, SERVICE_LOG_ID, "HTTP-GET", Long.toString(reqno));
+                LogUtil.logServerAccessStart(request, LogUtil.HYRAX_ACCESS_LOG_ID, "HTTP-GET", Long.toString(reqno));
                 LOG.debug(Util.getMemoryReport());
                 LOG.debug(ServletUtil.showRequest(request, reqno));
                 //log.debug(AwsUtil.probeRequest(this, request));
@@ -160,7 +159,7 @@ public class W10nServlet extends HttpServlet   {
             }
         }
         finally {
-            LogUtil.logServerAccessEnd(request_status, SERVICE_LOG_ID);
+            LogUtil.logServerAccessEnd(request_status, LogUtil.HYRAX_ACCESS_LOG_ID);
             RequestCache.closeThreadCache();
         }
 

--- a/src/opendap/wcs/v2_0/DummyCatalog.java
+++ b/src/opendap/wcs/v2_0/DummyCatalog.java
@@ -28,6 +28,7 @@ package opendap.wcs.v2_0;
 import org.jdom.Element;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.Vector;
 
 public class DummyCatalog implements WcsCatalog {
@@ -74,7 +75,7 @@ public class DummyCatalog implements WcsCatalog {
 
     @Override
     public long getLastModified() {
-        return 0;
+        return new Date().getTime();
     }
 
     @Override

--- a/src/opendap/wcs/v2_0/DynamicServiceCatalog.java
+++ b/src/opendap/wcs/v2_0/DynamicServiceCatalog.java
@@ -52,6 +52,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
@@ -539,7 +540,7 @@ public class DynamicServiceCatalog implements WcsCatalog{
 
     @Override
     public long getLastModified() {
-        return 0;
+        return new Date().getTime();
     }
 
     @Override

--- a/src/opendap/wcs/v2_0/http/Servlet.java
+++ b/src/opendap/wcs/v2_0/http/Servlet.java
@@ -72,7 +72,6 @@ public class Servlet extends HttpServlet {
     private static final AtomicInteger reqNumber = new AtomicInteger(0);
 
     private static final String DEFAULT_WCS_SERVICE_CONFIG_FILENAME = "wcs_service.xml";
-    private static final String WCS_ACCESS_LOG_ID = "WCS_2.0_ACCESS";
 
     private static final HttpGetHandler httpGetService = new HttpGetHandler();
     private static final FormHandler formService = new FormHandler();
@@ -204,7 +203,7 @@ public class Servlet extends HttpServlet {
 
         int request_status = HttpServletResponse.SC_OK;
         try {
-            LogUtil.logServerAccessStart(req, WCS_ACCESS_LOG_ID, "HTTP-GET", Integer.toString(reqNumber.incrementAndGet()));
+            LogUtil.logServerAccessStart(req, LogUtil.WCS_ACCESS_LOG_ID, "HTTP-GET", Integer.toString(reqNumber.incrementAndGet()));
             httpGetService.handleRequest(req, resp);
         }
         catch (Throwable t) {
@@ -258,7 +257,7 @@ public class Servlet extends HttpServlet {
             }
         }
         finally {
-            LogUtil.logServerAccessEnd(request_status, WCS_ACCESS_LOG_ID);
+            LogUtil.logServerAccessEnd(request_status, LogUtil.WCS_ACCESS_LOG_ID);
             RequestCache.closeThreadCache();
 
         }
@@ -270,7 +269,7 @@ public class Servlet extends HttpServlet {
     public void doPost(HttpServletRequest req, HttpServletResponse resp){
         int request_status = HttpServletResponse.SC_OK;
         try {
-            LogUtil.logServerAccessStart(req, WCS_ACCESS_LOG_ID, "HTTP-POST", Integer.toString(reqNumber.incrementAndGet()));
+            LogUtil.logServerAccessStart(req, LogUtil.WCS_ACCESS_LOG_ID, "HTTP-POST", Integer.toString(reqNumber.incrementAndGet()));
 
             if(wcsPostService.requestCanBeHandled(req)){
                 wcsPostService.handleRequest(req,resp);
@@ -306,7 +305,7 @@ public class Servlet extends HttpServlet {
             }
         }
         finally {
-            LogUtil.logServerAccessEnd(request_status, WCS_ACCESS_LOG_ID);
+            LogUtil.logServerAccessEnd(request_status, LogUtil.WCS_ACCESS_LOG_ID);
             RequestCache.closeThreadCache();
 
         }
@@ -318,11 +317,11 @@ public class Servlet extends HttpServlet {
         RequestCache.openThreadCache();
 
         long reqno = reqNumber.incrementAndGet();
-        LogUtil.logServerAccessStart(req, WCS_ACCESS_LOG_ID, "LastModified", Long.toString(reqno));
+        LogUtil.logServerAccessStart(req, LogUtil.WCS_LAST_MODIFIED_ACCESS_LOG_ID, "LastModified", Long.toString(reqno));
         try {
             return new Date().getTime();
         } finally {
-            LogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, WCS_ACCESS_LOG_ID);
+            LogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, LogUtil.WCS_LAST_MODIFIED_ACCESS_LOG_ID);
         }
 
 

--- a/src/opendap/wcs/v2_0/http/XmlRequestHandler.java
+++ b/src/opendap/wcs/v2_0/http/XmlRequestHandler.java
@@ -48,6 +48,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.*;
 import java.net.URLDecoder;
+import java.util.Date;
 
 /**
  * This class is responsible for processing WCS XML request documents.
@@ -114,7 +115,7 @@ public class XmlRequestHandler implements opendap.coreServlet.DispatchHandler, W
     }
 
     public long getLastModified(HttpServletRequest req) {
-        return -1;
+        return new Date().getTime();
     }
 
     public void destroy() {


### PR DESCRIPTION
In which I deal with a bunch of logging inconsistencies. Now we can more easily control (through configuration and not by changing source code) which of the various Hyrax services are logged to which files. Additionally we can, in most cases, separate GET/POST requests from getLastModified() operations. We can still log both if we wish, or log one or the other. 