### PR TITLE
Wcs redux

### DIFF
--- a/src/opendap/dap/Dap2Error.java
+++ b/src/opendap/dap/Dap2Error.java
@@ -1,5 +1,5 @@
 /////////////////////////////////////////////////////////////////////////////
-// This file is part of the "Java-DAP" project, a Java implementation
+// This file is part of the "Hyrax" project, a server implementation
 // of the OPeNDAP Data Access Protocol.
 //
 // Copyright (c) 2010, OPeNDAP, Inc.

--- a/src/opendap/dap4/Byte.java
+++ b/src/opendap/dap4/Byte.java
@@ -1,0 +1,14 @@
+package opendap.dap4;
+
+public class Byte  extends Variable {
+
+    public Byte(){
+        super();
+    }
+
+    public String toString()
+    {
+        return "Byte " + this.getName();
+    }
+
+}

--- a/src/opendap/dap4/Byte.java
+++ b/src/opendap/dap4/Byte.java
@@ -1,3 +1,29 @@
+/*
+ * /////////////////////////////////////////////////////////////////////////////
+ * // This file is part of the "Hyrax Data Server" project.
+ * //
+ * //
+ * // Copyright (c) 2019 OPeNDAP, Inc.
+ * // Author: Nathan David Potter  <ndp@opendap.org>
+ * //
+ * // This library is free software; you can redistribute it and/or
+ * // modify it under the terms of the GNU Lesser General Public
+ * // License as published by the Free Software Foundation; either
+ * // version 2.1 of the License, or (at your option) any later version.
+ * //
+ * // This library is distributed in the hope that it will be useful,
+ * // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * // Lesser General Public License for more details.
+ * //
+ * // You should have received a copy of the GNU Lesser General Public
+ * // License along with this library; if not, write to the Free Software
+ * // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+ * //
+ * // You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+ * /////////////////////////////////////////////////////////////////////////////
+ */
+
 package opendap.dap4;
 
 public class Byte  extends Variable {

--- a/src/opendap/dap4/Char.java
+++ b/src/opendap/dap4/Char.java
@@ -1,3 +1,28 @@
+/*
+ * /////////////////////////////////////////////////////////////////////////////
+ * // This file is part of the "Hyrax Data Server" project.
+ * //
+ * //
+ * // Copyright (c) 2019 OPeNDAP, Inc.
+ * // Author: Nathan David Potter  <ndp@opendap.org>
+ * //
+ * // This library is free software; you can redistribute it and/or
+ * // modify it under the terms of the GNU Lesser General Public
+ * // License as published by the Free Software Foundation; either
+ * // version 2.1 of the License, or (at your option) any later version.
+ * //
+ * // This library is distributed in the hope that it will be useful,
+ * // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * // Lesser General Public License for more details.
+ * //
+ * // You should have received a copy of the GNU Lesser General Public
+ * // License along with this library; if not, write to the Free Software
+ * // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+ * //
+ * // You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+ * /////////////////////////////////////////////////////////////////////////////
+ */
 package opendap.dap4;
 
 public class Char  extends Variable {

--- a/src/opendap/dap4/Char.java
+++ b/src/opendap/dap4/Char.java
@@ -1,0 +1,14 @@
+package opendap.dap4;
+
+public class Char  extends Variable {
+
+    public Char(){
+        super();
+    }
+
+    public String toString()
+    {
+        return "Char " + this.getName();
+    }
+
+}

--- a/src/opendap/dap4/Dap4Error.java
+++ b/src/opendap/dap4/Dap4Error.java
@@ -3,7 +3,7 @@
  * // This file is part of the "Hyrax Data Server" project.
  * //
  * //
- * // Copyright (c) 2013 OPeNDAP, Inc.
+ * // Copyright (c) 2019 OPeNDAP, Inc.
  * // Author: Nathan David Potter  <ndp@opendap.org>
  * //
  * // This library is free software; you can redistribute it and/or

--- a/src/opendap/dap4/Dap4Service.java
+++ b/src/opendap/dap4/Dap4Service.java
@@ -3,7 +3,7 @@
  * // This file is part of the "Hyrax Data Server" project.
  * //
  * //
- * // Copyright (c) 2015 OPeNDAP, Inc.
+ * // Copyright (c) 2019 OPeNDAP, Inc.
  * // Author: Nathan David Potter  <ndp@opendap.org>
  * //
  * // This library is free software; you can redistribute it and/or

--- a/src/opendap/dap4/DapString.java
+++ b/src/opendap/dap4/DapString.java
@@ -1,0 +1,12 @@
+package opendap.dap4;
+
+public class DapString  extends Variable {
+
+    public DapString(){
+        super();
+    }
+    public String toString()
+    {
+        return this.getName();
+    }
+}

--- a/src/opendap/dap4/Dataset.java
+++ b/src/opendap/dap4/Dataset.java
@@ -3,8 +3,8 @@
  * // This file is part of the "Hyrax Data Server" project.
  * //
  * //
- * // Copyright (c) 2017 OPeNDAP, Inc.
- * // Author: Uday Kari  <ukari@opendap.org>
+ * // Copyright (c) 2019 OPeNDAP, Inc.
+ * // Author: Nathan David Potter  <ndp@opendap.org>
  * //
  * // This library is free software; you can redistribute it and/or
  * // modify it under the terms of the GNU Lesser General Public

--- a/src/opendap/dap4/Dataset.java
+++ b/src/opendap/dap4/Dataset.java
@@ -58,10 +58,8 @@ public class Dataset {
     private List<Dimension> dimensions;
     private List<ContainerAttribute> attributes;
 
-    private List<Float64> vars64bitFloats;
-    private List<Float32> vars32bitFloats;
-    private List<Int64> vars64bitIntegers;
-    private List<Int32> vars32bitIntegers;
+    private Vector<Variable> variables;
+
 
     private boolean _checkedForCF;
     private boolean _isCFConvention;
@@ -75,10 +73,21 @@ public class Dataset {
         url = "";
         dimensions = new Vector<>();
         attributes = new Vector<>();
-        vars64bitFloats = new Vector<>();
-        vars32bitFloats = new Vector<>();
-        vars64bitIntegers = new Vector<>();
-        vars32bitIntegers = new Vector<>();
+        float64Vars = new Vector<>();
+        float32Vars = new Vector<>();
+        int64Vars = new Vector<>();
+        int32Vars = new Vector<>();
+        int16Vars = new Vector<>();
+        int8Vars = new Vector<>();
+        uInt64Vars = new Vector<>();
+        uInt32Vars = new Vector<>();
+        uInt16Vars = new Vector<>();
+        uInt8Vars = new Vector<>();
+        byteVars = new Vector<>();
+        charVars = new Vector<>();
+
+        variables = new Vector<>();
+
         _checkedForCF = false;
         _isCFConvention = false;
     }
@@ -100,7 +109,6 @@ public class Dataset {
     public String getUrl() {
         return url;
     }
-
     public void setUrl(String url) {
         this.url = url;
     }
@@ -109,8 +117,6 @@ public class Dataset {
     public List<ContainerAttribute> getAttributes() {
         return attributes;
     }
-
-
     public void setAttributes(List<ContainerAttribute> attributes) {
         this.attributes = attributes;
     }
@@ -119,61 +125,156 @@ public class Dataset {
     public List<Dimension> getDimensions() {
         return dimensions;
     }
-
     public void setDimensions(List<Dimension> dimensions) {
         this.dimensions = dimensions;
-    }
-
-    @XmlElement(name = "Float64")
-    public List<Float64> getVars64bitFloats() {
-        return vars64bitFloats;
-    }
-
-
-    public void setVars64bitFloats(List<Float64> vars64bitFloats) {
-        this.vars64bitFloats = vars64bitFloats;
-    }
-
-    @XmlElement(name = "Float32")
-    public List<Float32> getVars32bitFloats() {
-        return vars32bitFloats;
-    }
-
-
-    public void setVars32bitFloats(List<Float32> vars32bitFloats) {
-        this.vars32bitFloats = vars32bitFloats;
-    }
-
-    @XmlElement(name = "Int32")
-    public List<Int32> getVars32bitIntegers() {
-        return vars32bitIntegers;
-    }
-
-
-    public void setVars32bitIntegers(List<Int32> vars32bitIntegers) {
-        this.vars32bitIntegers = vars32bitIntegers;
-    }
-
-    @XmlElement(name = "Int64")
-    public List<Int64> getVars64bitIntegers() {
-        return vars64bitIntegers;
-    }
-
-    public void setVars64bitIntegers(List<Int64> vars64bitIntegers) {
-        this.vars64bitIntegers = vars64bitIntegers;
     }
 
     public Vector<Variable> getVariables() {
 
         Vector<Variable> vars = new Vector<>();
 
-        vars.addAll(getVars32bitFloats());
-        vars.addAll(getVars64bitFloats());
-        vars.addAll(getVars32bitIntegers());
-        vars.addAll(getVars64bitIntegers());
+        vars.addAll(float64Vars);
+        vars.addAll(float32Vars);
+
+        vars.addAll(int64Vars);
+        vars.addAll(uInt64Vars);
+
+        vars.addAll(int32Vars);
+        vars.addAll(uInt32Vars);
+
+        vars.addAll(int16Vars);
+        vars.addAll(uInt16Vars);
+
+        vars.addAll(int8Vars);
+        vars.addAll(uInt8Vars);
+
+        vars.addAll(byteVars);
+        vars.addAll(charVars);
 
         return vars;
     }
+
+
+
+
+    private List<Float64> float64Vars;
+    @XmlElement(name = "Float64")
+    public List<Float64> getFloat64Vars() {
+        return float64Vars;
+    }
+    public void setFloat64Vars(List<Float64> f64List) {
+        variables.addAll(f64List);
+        this.float64Vars = f64List;
+    }
+
+    private List<Float32> float32Vars;
+    @XmlElement(name = "Float32")
+    public List<Float32> getFloat32Vars() { return float32Vars; }
+    public void setFloat32Vars(List<Float32> f32List) {
+        variables.addAll(f32List);
+        this.float32Vars = f32List;
+    }
+
+    private List<Byte> byteVars;
+    @XmlElement(name = "UInt8")
+    public List<Byte> getByteVars() {
+        return byteVars;
+    }
+    public void setByteVars(List<Byte> byteList) {
+        variables.addAll(byteList);
+        byteVars = byteList;
+    }
+
+    private List<Char> charVars;
+    @XmlElement(name = "Char")
+    public List<Char> getCharVars() {
+        return charVars;
+    }
+    public void setCharVars(List<Char> charList) {
+        variables.addAll(charList);
+        charVars = charList;
+    }
+
+    private List<UInt8> uInt8Vars;
+    @XmlElement(name = "UInt8")
+    public List<UInt8> getUInt8Vars() {
+        return uInt8Vars;
+    }
+    public void setUInt8Vars(List<UInt8> uInt8List) {
+        variables.addAll(uInt8List);
+        uInt8Vars = uInt8List;
+    }
+
+    private List<Int8> int8Vars;
+    @XmlElement(name = "Int8")
+    public List<Int8> getInt8Vars() {
+        return int8Vars;
+    }
+    public void setInt8Vars(List<Int8> int8List) {
+        variables.addAll(int8List);
+        this.int8Vars = int8List;
+    }
+
+    private List<UInt16> uInt16Vars;
+    @XmlElement(name = "Int16")
+    public List<UInt16> getUInt16Vars() {
+        return uInt16Vars;
+    }
+    public void setUInt16Vars(List<UInt16> uInt16List) {
+        variables.addAll(uInt16List);
+        this.uInt16Vars = uInt16List;
+    }
+
+    private List<Int16> int16Vars;
+    @XmlElement(name = "Int16")
+    public List<Int16> getInt16Vars() {
+        return int16Vars;
+    }
+    public void setInt16Vars(List<Int16> int16List) {
+        variables.addAll(int16List);
+        this.int16Vars = int16List;
+    }
+
+    private List<UInt32> uInt32Vars;
+    @XmlElement(name = "UInt32")
+    public List<UInt32> getUInt32Vars() {
+        return uInt32Vars;
+    }
+    public void setUInt32Vars(List<UInt32> uInt32List) {
+        variables.addAll(uInt32List);
+        this.uInt32Vars = uInt32List;
+    }
+
+    private List<Int32> int32Vars;
+    @XmlElement(name = "Int32")
+    public List<Int32> getInt32Vars() {
+        return int32Vars;
+    }
+    public void setInt32Vars(List<Int32> int32List) {
+        variables.addAll(int32List);
+        this.int32Vars = int32List;
+    }
+
+    private List<UInt64> uInt64Vars;
+    @XmlElement(name = "UInt64")
+    public List<UInt64> getUInt64Vars() {
+        return uInt64Vars;
+    }
+    public void setUInt64Vars(List<UInt64> uInt64List) {
+        variables.addAll(uInt64List);
+        this.uInt64Vars = uInt64List;
+    }
+
+    private List<Int64> int64Vars;
+    @XmlElement(name = "Int64")
+    public List<Int64> getInt64Vars() {
+        return int64Vars;
+    }
+    public void setInt64Vars(List<Int64> int64List) {
+        variables.addAll(int64List);
+        this.int64Vars = int64List;
+    }
+
 
     /**
      * This finds the named Dimension if it exists.

--- a/src/opendap/dap4/Dataset.java
+++ b/src/opendap/dap4/Dataset.java
@@ -275,6 +275,16 @@ public class Dataset {
         this.int64Vars = int64List;
     }
 
+    private List<DapString> stringVars;
+    @XmlElement(name = "String")
+    public List<DapString> getStringVars() {
+        return stringVars;
+    }
+    public void setStringVars(List<DapString> stringList) {
+        variables.addAll(stringList);
+        this.stringVars = stringList;
+    }
+
 
     /**
      * This finds the named Dimension if it exists.

--- a/src/opendap/dap4/DatasetTest.java
+++ b/src/opendap/dap4/DatasetTest.java
@@ -112,7 +112,7 @@ public class DatasetTest {
     public void hasExactlyFiveFloat32Variables() {
         // multiple raw datasets can be tested with _datasetIsRaw, _datasetIsRaw1 etc
         Assume.assumeTrue(_datasetIsNotNull);
-        assertTrue(dataset.getVars32bitFloats().size() == 5);
+        assertTrue(dataset.getFloat32Vars().size() == 5);
     }
 
     @Test

--- a/src/opendap/dap4/Float32.java
+++ b/src/opendap/dap4/Float32.java
@@ -34,7 +34,7 @@ public class Float32 extends Variable {
 
 	public String toString()
 	{
-		return "Variable Type Float 32, name = " + this.getName();
+		return this.getName();
 	}
 	
 }

--- a/src/opendap/dap4/Float64.java
+++ b/src/opendap/dap4/Float64.java
@@ -34,6 +34,6 @@ public class Float64 extends Variable {
 
 	public String toString()
 	{
-		return "Variable Type Float 64, name = " + this.getName();
+		return this.getName();
 	}
 }

--- a/src/opendap/dap4/Int16.java
+++ b/src/opendap/dap4/Int16.java
@@ -1,0 +1,14 @@
+package opendap.dap4;
+
+public class Int16  extends Variable {
+
+    public Int16(){
+        super();
+    }
+
+    public String toString()
+    {
+        return this.getName();
+    }
+
+}

--- a/src/opendap/dap4/Int16.java
+++ b/src/opendap/dap4/Int16.java
@@ -1,3 +1,28 @@
+/*
+ * /////////////////////////////////////////////////////////////////////////////
+ * // This file is part of the "Hyrax Data Server" project.
+ * //
+ * //
+ * // Copyright (c) 2019 OPeNDAP, Inc.
+ * // Author: Nathan David Potter  <ndp@opendap.org>
+ * //
+ * // This library is free software; you can redistribute it and/or
+ * // modify it under the terms of the GNU Lesser General Public
+ * // License as published by the Free Software Foundation; either
+ * // version 2.1 of the License, or (at your option) any later version.
+ * //
+ * // This library is distributed in the hope that it will be useful,
+ * // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * // Lesser General Public License for more details.
+ * //
+ * // You should have received a copy of the GNU Lesser General Public
+ * // License along with this library; if not, write to the Free Software
+ * // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+ * //
+ * // You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+ * /////////////////////////////////////////////////////////////////////////////
+ */
 package opendap.dap4;
 
 public class Int16  extends Variable {

--- a/src/opendap/dap4/Int32.java
+++ b/src/opendap/dap4/Int32.java
@@ -3,8 +3,8 @@
  * // This file is part of the "Hyrax Data Server" project.
  * //
  * //
- * // Copyright (c) 2017 OPeNDAP, Inc.
- * // Author: Uday Kari  <ukari@opendap.org>
+ * // Copyright (c) 2019 OPeNDAP, Inc.
+ * // Author: Nathan David Potter  <ndp@opendap.org>
  * //
  * // This library is free software; you can redistribute it and/or
  * // modify it under the terms of the GNU Lesser General Public

--- a/src/opendap/dap4/Int32.java
+++ b/src/opendap/dap4/Int32.java
@@ -32,6 +32,6 @@ public class Int32 extends Variable {
 	}
 	public String toString()
 	{
-		return "Variable Type INT 32, name = " + this.getName();
+		return this.getName();
 	}
 }

--- a/src/opendap/dap4/Int64.java
+++ b/src/opendap/dap4/Int64.java
@@ -3,8 +3,8 @@
  * // This file is part of the "Hyrax Data Server" project.
  * //
  * //
- * // Copyright (c) 2017 OPeNDAP, Inc.
- * // Author: Uday Kari  <ukari@opendap.org>
+ * // Copyright (c) 2019 OPeNDAP, Inc.
+ * // Author: Nathan David Potter  <ndp@opendap.org>
  * //
  * // This library is free software; you can redistribute it and/or
  * // modify it under the terms of the GNU Lesser General Public

--- a/src/opendap/dap4/Int64.java
+++ b/src/opendap/dap4/Int64.java
@@ -32,6 +32,6 @@ public class Int64 extends Variable {
 	}
 	public String toString()
 	{
-		return "Variable Type INT 64, name = " + this.getName();
+		return this.getName();
 	}
 }

--- a/src/opendap/dap4/Int8.java
+++ b/src/opendap/dap4/Int8.java
@@ -1,3 +1,28 @@
+/*
+ * /////////////////////////////////////////////////////////////////////////////
+ * // This file is part of the "Hyrax Data Server" project.
+ * //
+ * //
+ * // Copyright (c) 2019 OPeNDAP, Inc.
+ * // Author: Nathan David Potter  <ndp@opendap.org>
+ * //
+ * // This library is free software; you can redistribute it and/or
+ * // modify it under the terms of the GNU Lesser General Public
+ * // License as published by the Free Software Foundation; either
+ * // version 2.1 of the License, or (at your option) any later version.
+ * //
+ * // This library is distributed in the hope that it will be useful,
+ * // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * // Lesser General Public License for more details.
+ * //
+ * // You should have received a copy of the GNU Lesser General Public
+ * // License along with this library; if not, write to the Free Software
+ * // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+ * //
+ * // You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+ * /////////////////////////////////////////////////////////////////////////////
+ */
 package opendap.dap4;
 
 public class Int8  extends Variable {

--- a/src/opendap/dap4/Int8.java
+++ b/src/opendap/dap4/Int8.java
@@ -1,0 +1,14 @@
+package opendap.dap4;
+
+public class Int8  extends Variable {
+
+    public Int8(){
+        super();
+    }
+
+    public String toString()
+    {
+        return this.getName();
+    }
+
+}

--- a/src/opendap/dap4/UInt16.java
+++ b/src/opendap/dap4/UInt16.java
@@ -1,3 +1,28 @@
+/*
+ * /////////////////////////////////////////////////////////////////////////////
+ * // This file is part of the "Hyrax Data Server" project.
+ * //
+ * //
+ * // Copyright (c) 2019 OPeNDAP, Inc.
+ * // Author: Nathan David Potter  <ndp@opendap.org>
+ * //
+ * // This library is free software; you can redistribute it and/or
+ * // modify it under the terms of the GNU Lesser General Public
+ * // License as published by the Free Software Foundation; either
+ * // version 2.1 of the License, or (at your option) any later version.
+ * //
+ * // This library is distributed in the hope that it will be useful,
+ * // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * // Lesser General Public License for more details.
+ * //
+ * // You should have received a copy of the GNU Lesser General Public
+ * // License along with this library; if not, write to the Free Software
+ * // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+ * //
+ * // You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+ * /////////////////////////////////////////////////////////////////////////////
+ */
 package opendap.dap4;
 
 public class UInt16  extends Variable {

--- a/src/opendap/dap4/UInt16.java
+++ b/src/opendap/dap4/UInt16.java
@@ -1,0 +1,14 @@
+package opendap.dap4;
+
+public class UInt16  extends Variable {
+
+    public UInt16(){
+        super();
+    }
+
+    public String toString()
+    {
+        return "UInt16 " + this.getName();
+    }
+
+}

--- a/src/opendap/dap4/UInt32.java
+++ b/src/opendap/dap4/UInt32.java
@@ -1,3 +1,28 @@
+/*
+ * /////////////////////////////////////////////////////////////////////////////
+ * // This file is part of the "Hyrax Data Server" project.
+ * //
+ * //
+ * // Copyright (c) 2019 OPeNDAP, Inc.
+ * // Author: Nathan David Potter  <ndp@opendap.org>
+ * //
+ * // This library is free software; you can redistribute it and/or
+ * // modify it under the terms of the GNU Lesser General Public
+ * // License as published by the Free Software Foundation; either
+ * // version 2.1 of the License, or (at your option) any later version.
+ * //
+ * // This library is distributed in the hope that it will be useful,
+ * // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * // Lesser General Public License for more details.
+ * //
+ * // You should have received a copy of the GNU Lesser General Public
+ * // License along with this library; if not, write to the Free Software
+ * // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+ * //
+ * // You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+ * /////////////////////////////////////////////////////////////////////////////
+ */
 package opendap.dap4;
 
 public class UInt32  extends Variable {

--- a/src/opendap/dap4/UInt32.java
+++ b/src/opendap/dap4/UInt32.java
@@ -1,0 +1,14 @@
+package opendap.dap4;
+
+public class UInt32  extends Variable {
+
+    public UInt32(){
+        super();
+    }
+
+    public String toString()
+    {
+        return "UInt32 " + this.getName();
+    }
+
+}

--- a/src/opendap/dap4/UInt64.java
+++ b/src/opendap/dap4/UInt64.java
@@ -1,3 +1,28 @@
+/*
+ * /////////////////////////////////////////////////////////////////////////////
+ * // This file is part of the "Hyrax Data Server" project.
+ * //
+ * //
+ * // Copyright (c) 2019 OPeNDAP, Inc.
+ * // Author: Nathan David Potter  <ndp@opendap.org>
+ * //
+ * // This library is free software; you can redistribute it and/or
+ * // modify it under the terms of the GNU Lesser General Public
+ * // License as published by the Free Software Foundation; either
+ * // version 2.1 of the License, or (at your option) any later version.
+ * //
+ * // This library is distributed in the hope that it will be useful,
+ * // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * // Lesser General Public License for more details.
+ * //
+ * // You should have received a copy of the GNU Lesser General Public
+ * // License along with this library; if not, write to the Free Software
+ * // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+ * //
+ * // You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+ * /////////////////////////////////////////////////////////////////////////////
+ */
 package opendap.dap4;
 
 public class UInt64  extends Variable {

--- a/src/opendap/dap4/UInt64.java
+++ b/src/opendap/dap4/UInt64.java
@@ -1,0 +1,14 @@
+package opendap.dap4;
+
+public class UInt64  extends Variable {
+
+    public UInt64(){
+        super();
+    }
+
+    public String toString()
+    {
+        return "UInt64 " + this.getName();
+    }
+
+}

--- a/src/opendap/dap4/UInt8.java
+++ b/src/opendap/dap4/UInt8.java
@@ -1,0 +1,14 @@
+package opendap.dap4;
+
+public class UInt8  extends Variable {
+
+    public UInt8(){
+        super();
+    }
+
+    public String toString()
+    {
+        return "UInt8 " + this.getName();
+    }
+
+}

--- a/src/opendap/dap4/UInt8.java
+++ b/src/opendap/dap4/UInt8.java
@@ -1,3 +1,28 @@
+/*
+ * /////////////////////////////////////////////////////////////////////////////
+ * // This file is part of the "Hyrax Data Server" project.
+ * //
+ * //
+ * // Copyright (c) 2019 OPeNDAP, Inc.
+ * // Author: Nathan David Potter  <ndp@opendap.org>
+ * //
+ * // This library is free software; you can redistribute it and/or
+ * // modify it under the terms of the GNU Lesser General Public
+ * // License as published by the Free Software Foundation; either
+ * // version 2.1 of the License, or (at your option) any later version.
+ * //
+ * // This library is distributed in the hope that it will be useful,
+ * // but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * // Lesser General Public License for more details.
+ * //
+ * // You should have received a copy of the GNU Lesser General Public
+ * // License along with this library; if not, write to the Free Software
+ * // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+ * //
+ * // You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+ * /////////////////////////////////////////////////////////////////////////////
+ */
 package opendap.dap4;
 
 public class UInt8  extends Variable {


### PR DESCRIPTION
This patch adds implementations for WCS variables held in Int8, Uint8, Int16, UInt16, UInt32, and UInt64 to augment the implementations of Float64, Float32, Int64, Int32