### PR TITLE
Patching regresion test baselines for changes caused by a change in t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,5 @@ foo.*
 /bin/
 /conf/
 /.sonar/
+/.scannerwork/
 /webapps

--- a/hyrax_tests/ff/avhrr.dat.dmr.html.baseline
+++ b/hyrax_tests/ff/avhrr.dat.dmr.html.baseline
@@ -775,7 +775,7 @@
         {
           "@type": "PropertyValue", 
           "name": "DODS_LonRange", 
-          "value": [ "\-96.2220", "\-33.7780" ]        },
+          "value": [ "-96.2220", "-33.7780" ]        },
         {
           "@type": "PropertyValue", 
           "name": "Sel_Vars", 
@@ -787,11 +787,11 @@
         {
           "@type": "PropertyValue", 
           "name": "DODS_StartDate", 
-          "value": "1979\/4\/11"        },
+          "value": "1979/4/11"        },
         {
           "@type": "PropertyValue", 
           "name": "DODS_EndDate", 
-          "value": "2002\/12\/31"        },
+          "value": "2002/12/31"        },
         {
           "@type": "PropertyValue", 
           "name": "year_variable", 

--- a/hyrax_tests/ff/avhrr.dat.html.baseline
+++ b/hyrax_tests/ff/avhrr.dat.html.baseline
@@ -772,7 +772,7 @@
         {
           "@type": "PropertyValue", 
           "name": "DODS_LonRange", 
-          "value": [ "\-96.2220", "\-33.7780" ]        },
+          "value": [ "-96.2220", "-33.7780" ]        },
         {
           "@type": "PropertyValue", 
           "name": "Sel_Vars", 
@@ -784,11 +784,11 @@
         {
           "@type": "PropertyValue", 
           "name": "DODS_StartDate", 
-          "value": "1979\/4\/11"        },
+          "value": "1979/4/11"        },
         {
           "@type": "PropertyValue", 
           "name": "DODS_EndDate", 
-          "value": "2002\/12\/31"        },
+          "value": "2002/12/31"        },
         {
           "@type": "PropertyValue", 
           "name": "year_variable", 

--- a/hyrax_tests/hdf4/S2000415.hdf.dmr.html.baseline
+++ b/hyrax_tests/hdf4/S2000415.hdf.dmr.html.baseline
@@ -3068,11 +3068,11 @@
         {
           "@type": "PropertyValue", 
           "name": "SIS_ID", 
-          "value": "597\-512\-24\/1996\-07\-01"        },
+          "value": "597-512-24/1996-07-01"        },
         {
           "@type": "PropertyValue", 
           "name": "Build_ID", 
-          "value": "3.2.1\/1996\-11\-05"        },
+          "value": "3.2.1/1996-11-05"        },
         {
           "@type": "PropertyValue", 
           "name": "ADEOS_Data_Package_ID", 
@@ -3084,7 +3084,7 @@
         {
           "@type": "PropertyValue", 
           "name": "Product_Creation_Time", 
-          "value": "1996\-318T01:35:16.000"        },
+          "value": "1996-318T01:35:16.000"        },
         {
           "@type": "PropertyValue", 
           "name": "Data_Type", 
@@ -3100,7 +3100,7 @@
         {
           "@type": "PropertyValue", 
           "name": "First_Rev_Eq_Crossing_Time", 
-          "value": "1996\-259T04:01:28.226"        },
+          "value": "1996-259T04:01:28.226"        },
         {
           "@type": "PropertyValue", 
           "name": "First_Rev_Eq_Crossing_Lon", 
@@ -3108,11 +3108,11 @@
         {
           "@type": "PropertyValue", 
           "name": "First_Data_Time", 
-          "value": "1996\-259T03:43:48.945"        },
+          "value": "1996-259T03:43:48.945"        },
         {
           "@type": "PropertyValue", 
           "name": "Last_Data_Time", 
-          "value": "1996\-259T05:09:48.997"        },
+          "value": "1996-259T05:09:48.997"        },
         {
           "@type": "PropertyValue", 
           "name": "Num_Expected_Output_Records", 
@@ -3128,11 +3128,11 @@
         {
           "@type": "PropertyValue", 
           "name": "HDF_Build_ID", 
-          "value": "JPL D\-xxxxx 12\/15\/94"        },
+          "value": "JPL D-xxxxx 12/15/94"        },
         {
           "@type": "PropertyValue", 
           "name": "HDF_SIS_ID", 
-          "value": "JPL D\-12060 12\/15\/94"        },
+          "value": "JPL D-12060 12/15/94"        },
         {
           "@type": "PropertyValue", 
           "name": "HDF_Conversion_Organization", 
@@ -3140,7 +3140,7 @@
         {
           "@type": "PropertyValue", 
           "name": "HDF_Conversion_Time", 
-          "value": "1996\-320T17:32:34"        },
+          "value": "1996-320T17:32:34"        },
         {
           "@type": "PropertyValue", 
           "name": "Data_Format_Type", 
@@ -3580,7 +3580,7 @@
       {
         "@type": "PropertyValue", 
         "name": "long_name", 
-        "value": "The total number of sigma\-0 measurements"      },
+        "value": "The total number of sigma-0 measurements"      },
       {
         "@type": "PropertyValue", 
         "name": "units", 
@@ -3618,7 +3618,7 @@
       {
         "@type": "PropertyValue", 
         "name": "long_name", 
-        "value": "The total number of sigma\-0s received from beam 1 or 2"      },
+        "value": "The total number of sigma-0s received from beam 1 or 2"      },
       {
         "@type": "PropertyValue", 
         "name": "units", 
@@ -3656,7 +3656,7 @@
       {
         "@type": "PropertyValue", 
         "name": "long_name", 
-        "value": "The total number of sigma\-0s received from beam 3 or 4"      },
+        "value": "The total number of sigma-0s received from beam 3 or 4"      },
       {
         "@type": "PropertyValue", 
         "name": "units", 
@@ -3694,7 +3694,7 @@
       {
         "@type": "PropertyValue", 
         "name": "long_name", 
-        "value": "The total number of sigma\-0s received from beam 5 or 6"      },
+        "value": "The total number of sigma-0s received from beam 5 or 6"      },
       {
         "@type": "PropertyValue", 
         "name": "units", 
@@ -3732,7 +3732,7 @@
       {
         "@type": "PropertyValue", 
         "name": "long_name", 
-        "value": "The total number of sigma\-0s received from beam 7 or 8"      },
+        "value": "The total number of sigma-0s received from beam 7 or 8"      },
       {
         "@type": "PropertyValue", 
         "name": "units", 
@@ -3808,7 +3808,7 @@
       {
         "@type": "PropertyValue", 
         "name": "units", 
-        "value": "m\/s"      },
+        "value": "m/s"      },
       {
         "@type": "PropertyValue", 
         "name": "scale_factor", 
@@ -3846,7 +3846,7 @@
       {
         "@type": "PropertyValue", 
         "name": "units", 
-        "value": "m\/s"      },
+        "value": "m/s"      },
       {
         "@type": "PropertyValue", 
         "name": "scale_factor", 
@@ -3922,7 +3922,7 @@
       {
         "@type": "PropertyValue", 
         "name": "units", 
-        "value": "m\/s"      },
+        "value": "m/s"      },
       {
         "@type": "PropertyValue", 
         "name": "scale_factor", 

--- a/hyrax_tests/hdf4/S2000415.hdf.html.baseline
+++ b/hyrax_tests/hdf4/S2000415.hdf.html.baseline
@@ -3050,11 +3050,11 @@
         {
           "@type": "PropertyValue", 
           "name": "SIS_ID", 
-          "value": "597\-512\-24\/1996\-07\-01"        },
+          "value": "597-512-24/1996-07-01"        },
         {
           "@type": "PropertyValue", 
           "name": "Build_ID", 
-          "value": "3.2.1\/1996\-11\-05"        },
+          "value": "3.2.1/1996-11-05"        },
         {
           "@type": "PropertyValue", 
           "name": "ADEOS_Data_Package_ID", 
@@ -3066,7 +3066,7 @@
         {
           "@type": "PropertyValue", 
           "name": "Product_Creation_Time", 
-          "value": "1996\-318T01:35:16.000"        },
+          "value": "1996-318T01:35:16.000"        },
         {
           "@type": "PropertyValue", 
           "name": "Data_Type", 
@@ -3082,7 +3082,7 @@
         {
           "@type": "PropertyValue", 
           "name": "First_Rev_Eq_Crossing_Time", 
-          "value": "1996\-259T04:01:28.226"        },
+          "value": "1996-259T04:01:28.226"        },
         {
           "@type": "PropertyValue", 
           "name": "First_Rev_Eq_Crossing_Lon", 
@@ -3090,11 +3090,11 @@
         {
           "@type": "PropertyValue", 
           "name": "First_Data_Time", 
-          "value": "1996\-259T03:43:48.945"        },
+          "value": "1996-259T03:43:48.945"        },
         {
           "@type": "PropertyValue", 
           "name": "Last_Data_Time", 
-          "value": "1996\-259T05:09:48.997"        },
+          "value": "1996-259T05:09:48.997"        },
         {
           "@type": "PropertyValue", 
           "name": "Num_Expected_Output_Records", 
@@ -3110,11 +3110,11 @@
         {
           "@type": "PropertyValue", 
           "name": "HDF_Build_ID", 
-          "value": "JPL D\-xxxxx 12\/15\/94"        },
+          "value": "JPL D-xxxxx 12/15/94"        },
         {
           "@type": "PropertyValue", 
           "name": "HDF_SIS_ID", 
-          "value": "JPL D\-12060 12\/15\/94"        },
+          "value": "JPL D-12060 12/15/94"        },
         {
           "@type": "PropertyValue", 
           "name": "HDF_Conversion_Organization", 
@@ -3122,7 +3122,7 @@
         {
           "@type": "PropertyValue", 
           "name": "HDF_Conversion_Time", 
-          "value": "1996\-320T17:32:34"        },
+          "value": "1996-320T17:32:34"        },
         {
           "@type": "PropertyValue", 
           "name": "Data_Format_Type", 
@@ -3492,7 +3492,7 @@
       {
         "@type": "PropertyValue", 
         "name": "long_name", 
-        "value": "The total number of sigma\-0 measurements"      },
+        "value": "The total number of sigma-0 measurements"      },
       {
         "@type": "PropertyValue", 
         "name": "units", 
@@ -3530,7 +3530,7 @@
       {
         "@type": "PropertyValue", 
         "name": "long_name", 
-        "value": "The total number of sigma\-0s received from beam 1 or 2"      },
+        "value": "The total number of sigma-0s received from beam 1 or 2"      },
       {
         "@type": "PropertyValue", 
         "name": "units", 
@@ -3568,7 +3568,7 @@
       {
         "@type": "PropertyValue", 
         "name": "long_name", 
-        "value": "The total number of sigma\-0s received from beam 3 or 4"      },
+        "value": "The total number of sigma-0s received from beam 3 or 4"      },
       {
         "@type": "PropertyValue", 
         "name": "units", 
@@ -3606,7 +3606,7 @@
       {
         "@type": "PropertyValue", 
         "name": "long_name", 
-        "value": "The total number of sigma\-0s received from beam 5 or 6"      },
+        "value": "The total number of sigma-0s received from beam 5 or 6"      },
       {
         "@type": "PropertyValue", 
         "name": "units", 
@@ -3644,7 +3644,7 @@
       {
         "@type": "PropertyValue", 
         "name": "long_name", 
-        "value": "The total number of sigma\-0s received from beam 7 or 8"      },
+        "value": "The total number of sigma-0s received from beam 7 or 8"      },
       {
         "@type": "PropertyValue", 
         "name": "units", 
@@ -3720,7 +3720,7 @@
       {
         "@type": "PropertyValue", 
         "name": "units", 
-        "value": "m\/s"      },
+        "value": "m/s"      },
       {
         "@type": "PropertyValue", 
         "name": "scale_factor", 
@@ -3758,7 +3758,7 @@
       {
         "@type": "PropertyValue", 
         "name": "units", 
-        "value": "m\/s"      },
+        "value": "m/s"      },
       {
         "@type": "PropertyValue", 
         "name": "scale_factor", 
@@ -3834,7 +3834,7 @@
       {
         "@type": "PropertyValue", 
         "name": "units", 
-        "value": "m\/s"      },
+        "value": "m/s"      },
       {
         "@type": "PropertyValue", 
         "name": "scale_factor", 

--- a/hyrax_tests/hdf4/S2000415.hdf_ArraySubset.dmr.html.baseline
+++ b/hyrax_tests/hdf4/S2000415.hdf_ArraySubset.dmr.html.baseline
@@ -1320,11 +1320,11 @@
         {
           "@type": "PropertyValue", 
           "name": "SIS_ID", 
-          "value": "597\-512\-24\/1996\-07\-01"        },
+          "value": "597-512-24/1996-07-01"        },
         {
           "@type": "PropertyValue", 
           "name": "Build_ID", 
-          "value": "3.2.1\/1996\-11\-05"        },
+          "value": "3.2.1/1996-11-05"        },
         {
           "@type": "PropertyValue", 
           "name": "ADEOS_Data_Package_ID", 
@@ -1336,7 +1336,7 @@
         {
           "@type": "PropertyValue", 
           "name": "Product_Creation_Time", 
-          "value": "1996\-318T01:35:16.000"        },
+          "value": "1996-318T01:35:16.000"        },
         {
           "@type": "PropertyValue", 
           "name": "Data_Type", 
@@ -1352,7 +1352,7 @@
         {
           "@type": "PropertyValue", 
           "name": "First_Rev_Eq_Crossing_Time", 
-          "value": "1996\-259T04:01:28.226"        },
+          "value": "1996-259T04:01:28.226"        },
         {
           "@type": "PropertyValue", 
           "name": "First_Rev_Eq_Crossing_Lon", 
@@ -1360,11 +1360,11 @@
         {
           "@type": "PropertyValue", 
           "name": "First_Data_Time", 
-          "value": "1996\-259T03:43:48.945"        },
+          "value": "1996-259T03:43:48.945"        },
         {
           "@type": "PropertyValue", 
           "name": "Last_Data_Time", 
-          "value": "1996\-259T05:09:48.997"        },
+          "value": "1996-259T05:09:48.997"        },
         {
           "@type": "PropertyValue", 
           "name": "Num_Expected_Output_Records", 
@@ -1380,11 +1380,11 @@
         {
           "@type": "PropertyValue", 
           "name": "HDF_Build_ID", 
-          "value": "JPL D\-xxxxx 12\/15\/94"        },
+          "value": "JPL D-xxxxx 12/15/94"        },
         {
           "@type": "PropertyValue", 
           "name": "HDF_SIS_ID", 
-          "value": "JPL D\-12060 12\/15\/94"        },
+          "value": "JPL D-12060 12/15/94"        },
         {
           "@type": "PropertyValue", 
           "name": "HDF_Conversion_Organization", 
@@ -1392,7 +1392,7 @@
         {
           "@type": "PropertyValue", 
           "name": "HDF_Conversion_Time", 
-          "value": "1996\-320T17:32:34"        },
+          "value": "1996-320T17:32:34"        },
         {
           "@type": "PropertyValue", 
           "name": "Data_Format_Type", 
@@ -1686,7 +1686,7 @@
       {
         "@type": "PropertyValue", 
         "name": "long_name", 
-        "value": "The total number of sigma\-0s received from beam 3 or 4"      },
+        "value": "The total number of sigma-0s received from beam 3 or 4"      },
       {
         "@type": "PropertyValue", 
         "name": "units", 

--- a/hyrax_tests/hdf4/S2000415.hdf_ArraySubset.html.baseline
+++ b/hyrax_tests/hdf4/S2000415.hdf_ArraySubset.html.baseline
@@ -1311,11 +1311,11 @@
         {
           "@type": "PropertyValue", 
           "name": "SIS_ID", 
-          "value": "597\-512\-24\/1996\-07\-01"        },
+          "value": "597-512-24/1996-07-01"        },
         {
           "@type": "PropertyValue", 
           "name": "Build_ID", 
-          "value": "3.2.1\/1996\-11\-05"        },
+          "value": "3.2.1/1996-11-05"        },
         {
           "@type": "PropertyValue", 
           "name": "ADEOS_Data_Package_ID", 
@@ -1327,7 +1327,7 @@
         {
           "@type": "PropertyValue", 
           "name": "Product_Creation_Time", 
-          "value": "1996\-318T01:35:16.000"        },
+          "value": "1996-318T01:35:16.000"        },
         {
           "@type": "PropertyValue", 
           "name": "Data_Type", 
@@ -1343,7 +1343,7 @@
         {
           "@type": "PropertyValue", 
           "name": "First_Rev_Eq_Crossing_Time", 
-          "value": "1996\-259T04:01:28.226"        },
+          "value": "1996-259T04:01:28.226"        },
         {
           "@type": "PropertyValue", 
           "name": "First_Rev_Eq_Crossing_Lon", 
@@ -1351,11 +1351,11 @@
         {
           "@type": "PropertyValue", 
           "name": "First_Data_Time", 
-          "value": "1996\-259T03:43:48.945"        },
+          "value": "1996-259T03:43:48.945"        },
         {
           "@type": "PropertyValue", 
           "name": "Last_Data_Time", 
-          "value": "1996\-259T05:09:48.997"        },
+          "value": "1996-259T05:09:48.997"        },
         {
           "@type": "PropertyValue", 
           "name": "Num_Expected_Output_Records", 
@@ -1371,11 +1371,11 @@
         {
           "@type": "PropertyValue", 
           "name": "HDF_Build_ID", 
-          "value": "JPL D\-xxxxx 12\/15\/94"        },
+          "value": "JPL D-xxxxx 12/15/94"        },
         {
           "@type": "PropertyValue", 
           "name": "HDF_SIS_ID", 
-          "value": "JPL D\-12060 12\/15\/94"        },
+          "value": "JPL D-12060 12/15/94"        },
         {
           "@type": "PropertyValue", 
           "name": "HDF_Conversion_Organization", 
@@ -1383,7 +1383,7 @@
         {
           "@type": "PropertyValue", 
           "name": "HDF_Conversion_Time", 
-          "value": "1996\-320T17:32:34"        },
+          "value": "1996-320T17:32:34"        },
         {
           "@type": "PropertyValue", 
           "name": "Data_Format_Type", 
@@ -1677,7 +1677,7 @@
       {
         "@type": "PropertyValue", 
         "name": "long_name", 
-        "value": "The total number of sigma\-0s received from beam 3 or 4"      },
+        "value": "The total number of sigma-0s received from beam 3 or 4"      },
       {
         "@type": "PropertyValue", 
         "name": "units", 

--- a/hyrax_tests/nc3/bears.nc.dmr.html.baseline
+++ b/hyrax_tests/nc3/bears.nc.dmr.html.baseline
@@ -674,7 +674,7 @@
         {
           "@type": "PropertyValue", 
           "name": "history", 
-          "value": "This is an example of a multi\-line global\\012attribute.  It could be used for representing the\\012processing history of the data, for example."        },
+          "value": "This is an example of a multi-line global\\012attribute.  It could be used for representing the\\012processing history of the data, for example."        },
         {
           "@type": "PropertyValue", 
           "name": "Unlimited_Dimension", 

--- a/hyrax_tests/nc3/bears.nc.html.baseline
+++ b/hyrax_tests/nc3/bears.nc.html.baseline
@@ -648,7 +648,7 @@
         {
           "@type": "PropertyValue", 
           "name": "history", 
-          "value": "This is an example of a multi\-line global\\012attribute.  It could be used for representing the\\012processing history of the data, for example."        },
+          "value": "This is an example of a multi-line global\\012attribute.  It could be used for representing the\\012processing history of the data, for example."        },
         {
           "@type": "PropertyValue", 
           "name": "Unlimited_Dimension", 

--- a/hyrax_tests/nc3/bears.nc_bears_aloan_i.dmr.html.baseline
+++ b/hyrax_tests/nc3/bears.nc_bears_aloan_i.dmr.html.baseline
@@ -465,7 +465,7 @@
         {
           "@type": "PropertyValue", 
           "name": "history", 
-          "value": "This is an example of a multi\-line global\\012attribute.  It could be used for representing the\\012processing history of the data, for example."        },
+          "value": "This is an example of a multi-line global\\012attribute.  It could be used for representing the\\012processing history of the data, for example."        },
         {
           "@type": "PropertyValue", 
           "name": "Unlimited_Dimension", 

--- a/hyrax_tests/nc3/bears.nc_bears_aloan_i.html.baseline
+++ b/hyrax_tests/nc3/bears.nc_bears_aloan_i.html.baseline
@@ -441,7 +441,7 @@
         {
           "@type": "PropertyValue", 
           "name": "history", 
-          "value": "This is an example of a multi\-line global\\012attribute.  It could be used for representing the\\012processing history of the data, for example."        },
+          "value": "This is an example of a multi-line global\\012attribute.  It could be used for representing the\\012processing history of the data, for example."        },
         {
           "@type": "PropertyValue", 
           "name": "Unlimited_Dimension", 

--- a/hyrax_tests/nc3/fnoc1.nc.html.baseline
+++ b/hyrax_tests/nc3/fnoc1.nc.html.baseline
@@ -603,11 +603,11 @@
         {
           "@type": "PropertyValue", 
           "name": "base_time", 
-          "value": "88\- 10\-00:00:00"        },
+          "value": "88- 10-00:00:00"        },
         {
           "@type": "PropertyValue", 
           "name": "title", 
-          "value": "FNOC UV wind components from 1988\- 10 to 1988\- 13."        },
+          "value": "FNOC UV wind components from 1988- 10 to 1988- 13."        },
         {
           "@type": "PropertyValue", 
           "name": "Unlimited_Dimension", 
@@ -629,7 +629,7 @@
       {
         "@type": "PropertyValue", 
         "name": "missing_value", 
-        "value": "\-32767"      },
+        "value": "-32767"      },
       {
         "@type": "PropertyValue", 
         "name": "scale_factor", 
@@ -649,7 +649,7 @@
       {
         "@type": "PropertyValue", 
         "name": "WOA01", 
-        "value": "\x22http:\/\/localhost\/junk\x22"      }
+        "value": "\"http://localhost/junk\""      }
     ]
   },
   {
@@ -667,7 +667,7 @@
       {
         "@type": "PropertyValue", 
         "name": "missing_value", 
-        "value": "\-32767"      },
+        "value": "-32767"      },
       {
         "@type": "PropertyValue", 
         "name": "scale_factor", 

--- a/hyrax_tests/nc3/fnoc1.nc_lat.dmr.html.baseline
+++ b/hyrax_tests/nc3/fnoc1.nc_lat.dmr.html.baseline
@@ -296,11 +296,11 @@
         {
           "@type": "PropertyValue", 
           "name": "base_time", 
-          "value": "88\- 10\-00:00:00"        },
+          "value": "88- 10-00:00:00"        },
         {
           "@type": "PropertyValue", 
           "name": "title", 
-          "value": "FNOC UV wind components from 1988\- 10 to 1988\- 13."        },
+          "value": "FNOC UV wind components from 1988- 10 to 1988- 13."        },
         {
           "@type": "PropertyValue", 
           "name": "Unlimited_Dimension", 

--- a/hyrax_tests/nc3/fnoc1.nc_lat.html.baseline
+++ b/hyrax_tests/nc3/fnoc1.nc_lat.html.baseline
@@ -278,11 +278,11 @@
         {
           "@type": "PropertyValue", 
           "name": "base_time", 
-          "value": "88\- 10\-00:00:00"        },
+          "value": "88- 10-00:00:00"        },
         {
           "@type": "PropertyValue", 
           "name": "title", 
-          "value": "FNOC UV wind components from 1988\- 10 to 1988\- 13."        },
+          "value": "FNOC UV wind components from 1988- 10 to 1988- 13."        },
         {
           "@type": "PropertyValue", 
           "name": "Unlimited_Dimension", 


### PR DESCRIPTION
 The baselines need updating to account for changes in the HTML directory pages and the IFH pages caused by a change in the JSON-LD encoding.