### PR TITLE
Ngap only

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -461,8 +461,7 @@
             description="Compiles the OLFS."
     >
         <echo level="info" message="AntFile: ${ant.file} Compiling OLFS"/>
-        <echo level="info"
-              message="Using the ${build.compiler} javac compiler"/>
+        <echo level="info" message="Using the ${build.compiler} javac compiler"/>
         <echo level="info" message="java.home (ant):       ${java.home}"/>
         <echo level="info" message="Target JVM Version:    ${compile.TARGET}"/>
         <echo level="info" message="Source Syntax Version: ${compile.SOURCE}"/>
@@ -875,14 +874,13 @@
 
         <!--
         Here we:
-         - Set the ware file name to ROOT.war to deploy in the root, aka "/",
+         - Set the WAR file name to ROOT.war to deploy in the root, aka "/",
            deployment context.
          - Utilize a special NGAP web.xml that deploys with the Hyrax
            authentication and authorization filters enabled
         -->
         <war destfile="${build.dist}/ROOT.war"
-             webxml="${ngapResources.dir}/web.xml"
-        >
+             webxml="${ngapResources.dir}/web.xml">
 
             <lib  refid="hyrax-libs"/>
             <lib  refid="wcs-libs"/>

--- a/build.xml
+++ b/build.xml
@@ -193,6 +193,9 @@
     <property name="build.hyrax.resources" location="${build.dir}/resources"/>
     <property name="hyraxResources.dir" location="${resources.dir}/hyrax"/>
 
+    <!-- property name="build.ngap.resources" location="${build.dir}/resources/ngap"/ -->
+    <property name="ngapResources.dir" location="${resources.dir}/ngap"/>
+
     <property name="robotsResources.dir" location="${resources.dir}/robots"/>
     <property name="build.robots.resources" location="${build.dir}/robots"/>
 
@@ -943,5 +946,102 @@
         <!-- Execute SonarQube Scanner for Ant Analysis -->
         <sonar:sonar />
     </target>
+
+
+
+
+
+    <target
+            name="ngap"
+            depends="clean,compile"
+            description="Performs a clean build of the core software and assembles the WAR file."
+    >
+        <echo level="info" message="Building Hyrax NGAP server war file."/>
+        <echo level="info" message="build.hyrax.resources: ${build.hyrax.resources}"/>
+        <echo level="info" message="ngapResources.dir:     ${ngapResources.dir}"/>
+        <echo level="info" message="build.dist:            ${build.dist}"/>
+
+        <!--
+        Here we:
+         - Set the ware file name to ROOT.war to deploy in the root, aka "/",
+           deployment context.
+         - Utilize a special NGAP web.xml that deploys with the Hyrax
+           authentication and authorization filters enabled
+        -->
+        <war destfile="${build.dist}/ROOT.war"
+             webxml="${ngapResources.dir}/web.xml"
+        >
+
+            <lib dir="${lib.dir}">
+                <include name="${owasp-encoder}"/>
+                <include name="${owasp-encoder-jsp}"/>
+
+                <include name="${json.lib}"/>
+                <include name="${jdom.lib}"/>
+                <include name="${junit.lib}"/>
+                <include name="${urlRewrite.lib}"/>
+
+                <include name="${commons-lang.lib}"/>
+                <include name="${commons-cli.lib}"/>
+                <include name="${commons-httpclient.lib}"/>
+                <include name="${commons-logging.lib}"/>
+                <include name="${commons-codec.lib}"/>
+
+                <include name="${http-components-httpclient.lib}"/>
+                <include name="${http-components-httpcore.lib}"/>
+
+                <include name="${commons-io.lib}"/>
+
+                <include name="${xercesImpl.lib}"/>
+                <include name="${xercesXmlApis.lib}"/>
+                <include name="${saxon-jdom.lib}"/>
+                <include name="${saxon-s9api.lib}"/>
+                <include name="${saxon.lib}"/>
+
+                <include name="${slf4j.lib}"/>
+                <include name="${logback-core.lib}"/>
+                <include name="${logback-classic.lib}"/>
+
+            </lib>
+            <lib dir="${wcs.lib.dir}">
+                <include name="${ogc-wcs.lib}"/>
+                <include name="${ogc-gml.lib}"/>
+                <include name="${ogc-swe.lib}"/>
+                <include name="${ogc-gmlcov.lib}"/>
+                <include name="${ogc-ows.lib}"/>
+                <include name="${ogc-jaxb.lib}"/>
+                <include name="${jaxb-core.lib}"/>
+                <include name="${jaxb-impl.lib}"/>
+                <include name="${xlink.lib}"/>
+            </lib>
+
+            <classes dir="${build.classes}"/>
+
+            <zipfileset dir="${build.hyrax.resources}" prefix="">
+                <include name="**/*"/>
+                <exclude name="WEB-INF/web.xml"/>
+                <exclude name="WEB-INF/urlrewrite.xml"/>
+            </zipfileset>
+
+            <!--
+            Special urlrewrite.xml that shunts requests to the ngap
+            service endpoint if they are not explicitly for the hyrax, wcs
+            or some other service endpoint.
+            -->
+            <zipfileset dir="${ngapResources.dir}" prefix="WEB-INF">
+                <include name="urlrewrite.xml"/>
+            </zipfileset>
+
+            <zipfileset dir="${doc.dir}" prefix="docs">
+                <exclude name="src.distribution.readme"/>
+            </zipfileset>
+
+        </war>
+
+        <delete file="${build.dist}/index.html"/>
+
+    </target>
+
+
 
 </project>

--- a/build.xml
+++ b/build.xml
@@ -258,49 +258,68 @@
     <property name="owasp-encoder" value="encoder-1.2.2.jar"/>
     <property name="owasp-encoder-jsp" value="encoder-jsp-1.2.2.jar"/>
 
+
+
+    <fileset id="hyrax-libs" dir="${lib.dir}">
+        <include name="${owasp-encoder}"/>
+        <include name="${owasp-encoder-jsp}"/>
+
+        <include name="${json.lib}"/>
+        <include name="${jdom.lib}"/>
+        <include name="${junit.lib}"/>
+
+        <include name="${commons-lang.lib}"/>
+        <include name="${commons-cli.lib}"/>
+        <include name="${commons-httpclient.lib}"/>
+        <include name="${commons-logging.lib}"/>
+        <include name="${commons-codec.lib}"/>
+
+        <include name="${http-components-httpclient.lib}"/>
+        <include name="${http-components-httpcore.lib}"/>
+
+        <include name="${commons-io.lib}"/>
+
+        <!-- include name="${xercesImpl.lib}"/>
+        <include name="${xercesXmlApis.lib}"/-->
+        <include name="${saxon-jdom.lib}"/>
+        <include name="${saxon-s9api.lib}"/>
+        <include name="${saxon.lib}"/>
+
+        <include name="${slf4j.lib}"/>
+        <include name="${logback-core.lib}"/>
+        <include name="${logback-classic.lib}"/>
+
+        <include name="${urlRewrite.lib}"/>
+    </fileset>
+
+    <fileset id="wcs-libs" dir="${wcs.lib.dir}">
+        <include name="${ogc-wcs.lib}"/>
+        <include name="${ogc-gml.lib}"/>
+        <include name="${ogc-swe.lib}"/>
+        <include name="${ogc-gmlcov.lib}"/>
+        <include name="${ogc-ows.lib}"/>
+        <include name="${ogc-jaxb.lib}"/>
+        <include name="${jaxb-core.lib}"/>
+        <include name="${jaxb-impl.lib}"/>
+    </fileset>
+
+
+
+
     <!-- Library (class)paths -->
     <path id="olfs.compile.classpath">
         <pathelement path="${build.classes}"/>
+        <!--
+            We have to have the catalina and servlet api's on the classpath at
+            compile time, but their not needed at deployment because they come
+            bundled with Tomcat
+        -->
         <fileset dir="${lib.dir}">
-            <include name="${servlet-api.lib}"/>
-            <include name="${owasp-encoder}"/>
-            <include name="${owasp-encoder-jsp}"/>
-            <include name="${json.lib}"/>
-            <include name="${jdom.lib}"/>
-            <include name="${junit.lib}"/>
-            <include name="${commons-cli.lib}"/>
-            <include name="${commons-httpclient.lib}"/>
-            <include name="${commons-logging.lib}"/>
-            <include name="${commons-codec.lib}"/>
-            <include name="${commons-lang.lib}"/>
-
-            <include name="${http-components-httpclient.lib}"/>
-            <include name="${http-components-httpcore.lib}"/>
-
-            <include name="${commons-io.lib}"/>
-
-            <include name="${saxon-jdom.lib}"/>
-            <include name="${saxon-s9api.lib}"/>
-            <include name="${saxon.lib}"/>
-
             <include name="${catalina.lib}"/>
-
-            <include name="${slf4j.lib}"/>
-            <include name="${logback-core.lib}"/>
-            <include name="${logback-classic.lib}"/>
+            <include name="${servlet-api.lib}"/>
         </fileset>
-        <fileset dir="${wcs.lib.dir}">
-            <include name="${ogc-wcs.lib}"/>
-            <include name="${ogc-gml.lib}"/>
-            <include name="${ogc-swe.lib}"/>
-            <include name="${ogc-gmlcov.lib}"/>
-            <include name="${ogc-ows.lib}"/>
-            <include name="${ogc-jaxb.lib}"/>
-            <include name="${jaxb-core.lib}"/>
-            <include name="${jaxb-impl.lib}"/>
-            <include name="${xlink.lib}"/>
-        </fileset>
-
+        <fileset refid="hyrax-libs" />
+        <fileset refid="wcs-libs" />
     </path>
 
 
@@ -363,9 +382,9 @@
         </junit>
     </target>
 
-	<!-- Alias for Travis which expects tests to be run by 'ant test' jhrg 3/14/19 -->
+    <!-- Alias for Travis which expects tests to be run by 'ant test' jhrg 3/14/19 -->
     <target name="test" depends="check"/>
-	
+
     <target name="PreProcessSourceCode"
             depends="clean,init"
             description="Moves selected source code from the development tree into
@@ -502,43 +521,7 @@
 
     </target>
 
-<!--
-    <target
-            name="javaDoc"
-            depends="clean,PreProcessSourceCode,IsJavaDocUpToDate"
-            description="Builds JavaDoc for the Serve4 software packages, if missing or out of date."
-            unless="JavaDocIsUpToDate"
-    >
 
-        <javadoc destdir="${build.docs}/javadoc"
-                 Author="true"
-                 Verbose="true"
-                 Version="true"
-                 failonerror="true"
-                 additionalparam="-Xdoclint:none"
-        >
-            <classpath refid="olfs.compile.classpath"/>
-
-            <packageset dir="${build.src}" defaultexcludes="yes"/>
-
-
-        </javadoc>
-
-    </target>
-
-    <target name="doc-dist"
-            depends="clean,javaDoc"
-            description="Builds documentation distribution"
-    >
-
-        <tar destfile="${build.dist}/${DOC_DIST}.tgz"
-             compression="gzip"
-        >
-            <zipfileset dir="${build.docs}" prefix="${DOC_DIST}"/>
-        </tar>
-
-    </target>
--->
 
 
     <target name="src-dist"
@@ -753,48 +736,8 @@
              webxml="${build.hyrax.resources}/WEB-INF/web.xml"
         >
 
-            <lib dir="${lib.dir}">
-                <include name="${owasp-encoder}"/>
-                <include name="${owasp-encoder-jsp}"/>
-
-                <include name="${json.lib}"/>
-                <include name="${jdom.lib}"/>
-                <include name="${junit.lib}"/>
-                <include name="${urlRewrite.lib}"/>
-
-                <include name="${commons-lang.lib}"/>
-                <include name="${commons-cli.lib}"/>
-                <include name="${commons-httpclient.lib}"/>
-                <include name="${commons-logging.lib}"/>
-                <include name="${commons-codec.lib}"/>
-
-                <include name="${http-components-httpclient.lib}"/>
-                <include name="${http-components-httpcore.lib}"/>
-
-                <include name="${commons-io.lib}"/>
-
-                <include name="${xercesImpl.lib}"/>
-                <include name="${xercesXmlApis.lib}"/>
-                <include name="${saxon-jdom.lib}"/>
-                <include name="${saxon-s9api.lib}"/>
-                <include name="${saxon.lib}"/>
-
-                <include name="${slf4j.lib}"/>
-                <include name="${logback-core.lib}"/>
-                <include name="${logback-classic.lib}"/>
-
-            </lib>
-            <lib dir="${wcs.lib.dir}">
-                <include name="${ogc-wcs.lib}"/>
-                <include name="${ogc-gml.lib}"/>
-                <include name="${ogc-swe.lib}"/>
-                <include name="${ogc-gmlcov.lib}"/>
-                <include name="${ogc-ows.lib}"/>
-                <include name="${ogc-jaxb.lib}"/>
-                <include name="${jaxb-core.lib}"/>
-                <include name="${jaxb-impl.lib}"/>
-                <include name="${xlink.lib}"/>
-            </lib>
+            <lib refid="hyrax-libs" />
+            <lib refid="wcs-libs" />
 
             <classes dir="${build.classes}"/>
 
@@ -832,37 +775,7 @@
              webxml="${build.robots.resources}/WEB-INF/web.xml"
         >
 
-            <lib dir="${lib.dir}">
-                <include name="${owasp-encoder}"/>
-                <include name="${owasp-encoder-jsp}"/>
-
-                <include name="${json.lib}"/>
-                <include name="${jdom.lib}"/>
-                <include name="${junit.lib}"/>
-                <include name="${urlRewrite.lib}"/>
-
-                <include name="${commons-lang.lib}"/>
-                <include name="${commons-cli.lib}"/>
-                <include name="${commons-httpclient.lib}"/>
-                <include name="${commons-logging.lib}"/>
-                <include name="${commons-codec.lib}"/>
-
-                <include name="${http-components-httpclient.lib}"/>
-                <include name="${http-components-httpcore.lib}"/>
-
-                <include name="${commons-io.lib}"/>
-
-                <include name="${xercesImpl.lib}"/>
-                <include name="${xercesXmlApis.lib}"/>
-                <include name="${saxon-jdom.lib}"/>
-                <include name="${saxon-s9api.lib}"/>
-                <include name="${saxon.lib}"/>
-
-                <include name="${slf4j.lib}"/>
-                <include name="${logback-core.lib}"/>
-                <include name="${logback-classic.lib}"/>
-
-            </lib>
+            <lib refid="hyrax-libs" />
 
             <classes dir="${build.classes}"/>
 
@@ -923,30 +836,29 @@
     </target>
 
     <!-- SonarCloud build stuff -->
-	  <!-- Define the SonarQube global properties (the most usual way is to pass these properties via the command line) -->
-	  <property name="sonar.host.url" value="https://sonarcloud.io" />
-	  <property name="sonar.login" value="ping... ping... ping..." />
+    <!-- Define the SonarQube global properties (the most usual way is to pass these properties via the command line) -->
+    <property name="sonar.host.url" value="https://sonarcloud.io" />
+    <property name="sonar.login" value="ping... ping... ping..." />
 
-	  <!-- Define the SonarQube project properties -->
-	  <property name="sonar.projectKey" value="opendap-olfs" />
-	  <property name="sonar.projectName" value="olfs" />
-	  <property name="sonar.projectVersion" value="${OLFS_VERSION}" />
-	  <property name="sonar.organization" value="opendap" />
-	  <property name="sonar.sources" value="src" />
-	  <property name="sonar.exclusions" value="src/opendap/experiments/**/*.java,src/opendap/metacat/**/*.java,src/opendap/aws/**/*.java,src/opendap/noaa_s3/**/*.java" />
-	  <property name="sonar.java.binaries" value="build" />
-	  <property name="sonar.java.libraries" value="lib/*.jar" />
+    <!-- Define the SonarQube project properties -->
+    <property name="sonar.projectKey" value="opendap-olfs" />
+    <property name="sonar.projectName" value="olfs" />
+    <property name="sonar.projectVersion" value="${OLFS_VERSION}" />
+    <property name="sonar.organization" value="opendap" />
+    <property name="sonar.sources" value="src" />
+    <property name="sonar.exclusions" value="src/opendap/experiments/**/*.java,src/opendap/metacat/**/*.java,src/opendap/aws/**/*.java,src/opendap/noaa_s3/**/*.java" />
+    <property name="sonar.java.binaries" value="build" />
+    <property name="sonar.java.libraries" value="lib/*.jar" />
 
-	  <!-- Define SonarQube Scanner for Ant Target -->
-	  <target name="sonar">
-	      <taskdef uri="antlib:org.sonar.ant" resource="org/sonar/ant/antlib.xml">
-	          <classpath path="resources/sonar/sonarqube-ant-task-2.6.0.1426.jar" />
-	      </taskdef>
-	      <!-- taskdef uri="antlib:org.sonar.ant" resource="org/sonar/ant/antlib.xml" / -->
+    <!-- Define SonarQube Scanner for Ant Target -->
+    <target name="sonar">
+        <taskdef uri="antlib:org.sonar.ant" resource="org/sonar/ant/antlib.xml">
+            <classpath path="resources/sonar/sonarqube-ant-task-2.6.0.1426.jar" />
+        </taskdef>
+        <!-- taskdef uri="antlib:org.sonar.ant" resource="org/sonar/ant/antlib.xml" / -->
         <!-- Execute SonarQube Scanner for Ant Analysis -->
         <sonar:sonar />
     </target>
-
 
 
 
@@ -972,48 +884,8 @@
              webxml="${ngapResources.dir}/web.xml"
         >
 
-            <lib dir="${lib.dir}">
-                <include name="${owasp-encoder}"/>
-                <include name="${owasp-encoder-jsp}"/>
-
-                <include name="${json.lib}"/>
-                <include name="${jdom.lib}"/>
-                <include name="${junit.lib}"/>
-                <include name="${urlRewrite.lib}"/>
-
-                <include name="${commons-lang.lib}"/>
-                <include name="${commons-cli.lib}"/>
-                <include name="${commons-httpclient.lib}"/>
-                <include name="${commons-logging.lib}"/>
-                <include name="${commons-codec.lib}"/>
-
-                <include name="${http-components-httpclient.lib}"/>
-                <include name="${http-components-httpcore.lib}"/>
-
-                <include name="${commons-io.lib}"/>
-
-                <include name="${xercesImpl.lib}"/>
-                <include name="${xercesXmlApis.lib}"/>
-                <include name="${saxon-jdom.lib}"/>
-                <include name="${saxon-s9api.lib}"/>
-                <include name="${saxon.lib}"/>
-
-                <include name="${slf4j.lib}"/>
-                <include name="${logback-core.lib}"/>
-                <include name="${logback-classic.lib}"/>
-
-            </lib>
-            <lib dir="${wcs.lib.dir}">
-                <include name="${ogc-wcs.lib}"/>
-                <include name="${ogc-gml.lib}"/>
-                <include name="${ogc-swe.lib}"/>
-                <include name="${ogc-gmlcov.lib}"/>
-                <include name="${ogc-ows.lib}"/>
-                <include name="${ogc-jaxb.lib}"/>
-                <include name="${jaxb-core.lib}"/>
-                <include name="${jaxb-impl.lib}"/>
-                <include name="${xlink.lib}"/>
-            </lib>
+            <lib  refid="hyrax-libs"/>
+            <lib  refid="wcs-libs"/>
 
             <classes dir="${build.classes}"/>
 

--- a/resources/ngap/urlrewrite.xml
+++ b/resources/ngap/urlrewrite.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ /////////////////////////////////////////////////////////////////////////////
+  ~ // This file is part of the "Hyrax Data Server" project.
+  ~ //
+  ~ //
+  ~ // Copyright (c) 2013 OPeNDAP, Inc.
+  ~ // Author: Nathan David Potter  <ndp@opendap.org>
+  ~ //
+  ~ // This library is free software; you can redistribute it and/or
+  ~ // modify it under the terms of the GNU Lesser General Public
+  ~ // License as published by the Free Software Foundation; either
+  ~ // version 2.1 of the License, or (at your option) any later version.
+  ~ //
+  ~ // This library is distributed in the hope that it will be useful,
+  ~ // but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  ~ // Lesser General Public License for more details.
+  ~ //
+  ~ // You should have received a copy of the GNU Lesser General Public
+  ~ // License along with this library; if not, write to the Free Software
+  ~ // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+  ~ //
+  ~ // You can contact OPeNDAP, Inc. at PO Box 112, Saunderstown, RI. 02874-0112.
+  ~ /////////////////////////////////////////////////////////////////////////////
+  -->
+
+<!DOCTYPE urlrewrite PUBLIC "-//tuckey.org//DTD UrlRewrite 3.2//EN"
+        "http://tuckey.org/res/dtds/urlrewrite3.2.dtd">
+
+<urlrewrite>
+
+    <rule>
+         <set name="doRedirect">1</set>
+    </rule>
+
+    <rule>
+        <from>^/(wcs|admin|pdpService|hai|error|docs|jsp|viewers|xsl|hyrax|w10n|servlet_gateway|js|aggregation|siteMap)(/.*)?$</from>
+        <set name="doRedirect">0</set>
+    </rule>
+
+    <!--
+    The following rule shunts requests to the ngap
+    service endpoint if they are not explicitly for the hyrax, wcs
+    or some other service endpoint.
+    -->
+    <rule>
+        <condition type="attribute" name="doRedirect" operator="equal">1</condition>
+        <from>^/(.*)$</from>
+        <to last="true">/hyrax/ngap/$1</to>
+    </rule>
+
+    <rule>
+        <from>^/(.*)help/?$</from>
+        <to last="true">/jsp/help.jsp</to>
+    </rule>
+
+
+</urlrewrite>
+

--- a/resources/ngap/web.xml
+++ b/resources/ngap/web.xml
@@ -1,0 +1,451 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+    version="2.5">
+
+  <!-- ======================== Introduction ============================== -->
+  <!-- This document defines default values for *all* web applications      -->
+  <!-- loaded into this instance of Tomcat.  As each application is         -->
+  <!-- deployed, this file is processed, followed by the                    -->
+  <!-- "/WEB-INF/web.xml" deployment descriptor from your own               -->
+  <!-- applications.                                                        -->
+  <!--                                                                      -->
+  <!-- WARNING:  Do not configure application-specific resources here!      -->
+  <!-- They should go in the "/WEB-INF/web.xml" file in your application.   -->
+
+
+  <!-- ================== Built In Servlet Definitions ==================== -->
+
+    <display-name>Hyrax</display-name>
+    <description>OPeNDAP Hyrax Server</description>
+
+
+  <!-- The JSP page compiler and execution servlet, which is the mechanism  -->
+  <!-- used by Tomcat to support JSP pages.  Traditionally, this servlet    -->
+  <!-- is mapped to the URL pattern "*.jsp".  This servlet supports the     -->
+  <!-- following initialization parameters (default values are in square    -->
+  <!-- brackets):                                                           -->
+  <!--                                                                      -->
+  <!--   checkInterval       If development is false and checkInterval is   -->
+  <!--                       greater than zero, background compilations are -->
+  <!--                       enabled. checkInterval is the time in seconds  -->
+  <!--                       between checks to see if a JSP page (and its   -->
+  <!--                       dependent files) needs to  be recompiled. [0]  -->
+  <!--                                                                      -->
+  <!--   classdebuginfo      Should the class file be compiled with         -->
+  <!--                       debugging information?  [true]                 -->
+  <!--                                                                      -->
+  <!--   classpath           What class path should I use while compiling   -->
+  <!--                       generated servlets?  [Created dynamically      -->
+  <!--                       based on the current web application]          -->
+  <!--                                                                      -->
+  <!--   compiler            Which compiler Ant should use to compile JSP   -->
+  <!--                       pages.  See the jasper documentation for more  -->
+  <!--                       information.                                   -->
+  <!--                                                                      -->
+  <!--   compilerSourceVM    Compiler source VM. [1.5]                      -->
+  <!--                                                                      -->
+  <!--   compilerTargetVM    Compiler target VM. [1.5]                      -->
+  <!--                                                                      -->
+  <!--   development         Is Jasper used in development mode? If true,   -->
+  <!--                       the frequency at which JSPs are checked for    -->
+  <!--                       modification may be specified via the          -->
+  <!--                       modificationTestInterval parameter. [true]     -->
+  <!--                                                                      -->
+  <!--   displaySourceFragment                                              -->
+  <!--                       Should a source fragment be included in        -->
+  <!--                       exception messages? [true]                     -->
+  <!--                                                                      -->
+  <!--   dumpSmap            Should the SMAP info for JSR45 debugging be    -->
+  <!--                       dumped to a file? [false]                      -->
+  <!--                       False if suppressSmap is true                  -->
+  <!--                                                                      -->
+  <!--   enablePooling       Determines whether tag handler pooling is      -->
+  <!--                       enabled. This is a compilation option. It will -->
+  <!--                       not alter the behaviour of JSPs that have      -->
+  <!--                       already been compiled. [true]                  -->
+  <!--                                                                      -->
+  <!--   engineOptionsClass  Allows specifying the Options class used to    -->
+  <!--                       configure Jasper. If not present, the default  -->
+  <!--                       EmbeddedServletOptions will be used.           -->
+  <!--                                                                      -->
+  <!--   errorOnUseBeanInvalidClassAttribute                                -->
+  <!--                       Should Jasper issue an error when the value of -->
+  <!--                       the class attribute in an useBean action is    -->
+  <!--                       not a valid bean class?  [true]                -->
+  <!--                                                                      -->
+  <!--   fork                Tell Ant to fork compiles of JSP pages so that -->
+  <!--                       a separate JVM is used for JSP page compiles   -->
+  <!--                       from the one Tomcat is running in. [true]      -->
+  <!--                                                                      -->
+  <!--   genStrAsCharArray   Should text strings be generated as char       -->
+  <!--                       arrays, to improve performance in some cases?  -->
+  <!--                       [false]                                        -->
+  <!--                                                                      -->
+  <!--   ieClassId           The class-id value to be sent to Internet      -->
+  <!--                       Explorer when using <jsp:plugin> tags.         -->
+  <!--                       [clsid:8AD9C840-044E-11D1-B3E9-00805F499D93]   -->
+  <!--                                                                      -->
+  <!--   javaEncoding        Java file encoding to use for generating java  -->
+  <!--                       source files. [UTF8]                           -->
+  <!--                                                                      -->
+  <!--   keepgenerated       Should we keep the generated Java source code  -->
+  <!--                       for each page instead of deleting it? [true]   -->
+  <!--                                                                      -->
+  <!--   mappedfile          Should we generate static content with one     -->
+  <!--                       print statement per input line, to ease        -->
+  <!--                       debugging?  [true]                             -->
+  <!--                                                                      -->
+  <!--   modificationTestInterval                                           -->
+  <!--                       Causes a JSP (and its dependent files) to not  -->
+  <!--                       be checked for modification during the         -->
+  <!--                       specified time interval (in seconds) from the  -->
+  <!--                       last time the JSP was checked for              -->
+  <!--                       modification. A value of 0 will cause the JSP  -->
+  <!--                       to be checked on every access.                 -->
+  <!--                       Used in development mode only. [4]             -->
+  <!--                                                                      -->
+  <!--   scratchdir          What scratch directory should we use when      -->
+  <!--                       compiling JSP pages?  [default work directory  -->
+  <!--                       for the current web application]               -->
+  <!--                                                                      -->
+  <!--   suppressSmap        Should the generation of SMAP info for JSR45   -->
+  <!--                       debugging be suppressed?  [false]              -->
+  <!--                                                                      -->
+  <!--   trimSpaces          Should white spaces in template text between   -->
+  <!--                       actions or directives be trimmed?  [false]     -->
+  <!--                                                                      -->
+  <!--   xpoweredBy          Determines whether X-Powered-By response       -->
+  <!--                       header is added by generated servlet  [false]  -->
+  <!--                                                                      -->
+  <!-- If you wish to use Jikes to compile JSP pages:                       -->
+  <!--   Please see the "Using Jikes" section of the Jasper-HowTo           -->
+  <!--   page in the Tomcat documentation.                                  -->
+
+    <filter>
+        <filter-name>ClickJackFilter</filter-name>
+        <filter-class>opendap.coreServlet.ClickjackFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>ClickJackFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+    <!-- Uncomment These two filters to enable access control. -->
+
+    <filter>
+        <filter-name>IdP</filter-name>
+        <filter-class>opendap.auth.IdFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>IdP</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <filter>
+        <filter-name>PEP</filter-name>
+        <filter-class>opendap.auth.PEPFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>PEP</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+
+    <!--  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        Catalog Response Cache Updater (worker thread)
+    -->
+    <!-- Currently disabled...
+    <listener>
+        <listener-class>opendap.bes.caching.CatalogCacheUpdater</listener-class>
+    </listener>
+    -->
+<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <servlet>
+        <servlet-name>hyrax</servlet-name>
+
+        <servlet-class>opendap.coreServlet.DispatchServlet</servlet-class>
+
+        <init-param>
+            <param-name>DebugOn</param-name>
+            <param-value>true</param-value>
+        </init-param>
+
+        <init-param>
+            <param-name>ConfigFileName</param-name>
+            <param-value>olfs.xml</param-value>
+        </init-param>
+
+        <load-on-startup>1</load-on-startup>
+
+    </servlet>
+
+    <!-- - - - - - - - - WCS Servlet - - - - - - - - - -->
+    <servlet>
+        <servlet-name>wcs</servlet-name>
+        <servlet-class>opendap.wcs.v2_0.http.Servlet</servlet-class>
+        <init-param>
+            <param-name>WCSConfigFileName</param-name>
+            <param-value>wcs_service.xml</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - -->
+
+
+    <servlet>
+        <servlet-name>w10n</servlet-name>
+        <servlet-class>opendap.w10n.W10nServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet>
+        <servlet-name>aggregation</servlet-name>
+        <servlet-class>opendap.aggregation.AggregationServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet>
+        <servlet-name>adminInterface</servlet-name>
+        <servlet-class>opendap.hai.DispatchServlet</servlet-class>
+        <!-- init-param>
+            <param-name>DeveloperMode</param-name>
+            <param-value>true</param-value>
+        </init-param -->
+        <!-- Most people don't use the HAI, so don't load it by default -->
+        <!-- load-on-startup>1</load-on-startup -->
+    </servlet>
+
+    <servlet>
+        <servlet-name>viewers</servlet-name>
+
+        <servlet-class>opendap.viewers.ViewersServlet</servlet-class>
+
+        <init-param>
+            <param-name>ConfigFileName</param-name>
+            <param-value>viewers.xml</param-value>
+        </init-param>
+
+        <load-on-startup>1</load-on-startup>
+
+    </servlet>
+
+    <servlet>
+        <servlet-name>docs_servlet</servlet-name>
+        <servlet-class>opendap.coreServlet.DocServlet </servlet-class>
+        <!--servlet-class>org.apache.catalina.servlets.DefaultServlet</servlet-class -->
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <!-- moved to the robots.txt service -->
+    <servlet>
+        <servlet-name>site_map_service</servlet-name>
+        <servlet-class>opendap.bes.BESSiteMapService</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <!-- servlet>
+        <servlet-name>echo</servlet-name>
+        <servlet-class>opendap.experiments.EchoServlet </servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet -->
+
+    <filter>
+        <filter-name>UrlRewriteFilter</filter-name>
+        <filter-class>org.tuckey.web.filters.urlrewrite.UrlRewriteFilter</filter-class>
+        <init-param>
+            <param-name>logLevel</param-name>
+            <param-value>sysout:DEBUG</param-value>
+        </init-param>
+        <init-param>
+            <param-name>RewriteLog</param-name>
+            <param-value>log4j</param-value>
+        </init-param>
+    </filter>
+
+    <filter-mapping>
+        <filter-name>UrlRewriteFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+        <dispatcher>REQUEST</dispatcher>
+        <dispatcher>FORWARD</dispatcher>
+        <dispatcher>INCLUDE</dispatcher>
+        <dispatcher>ERROR</dispatcher>
+    </filter-mapping>
+
+    <!-- servlet-mapping>
+        <servlet-name>echo</servlet-name>
+        <url-pattern>/echo/*</url-pattern>
+    </servlet-mapping -->
+
+    <servlet-mapping>
+        <servlet-name>site_map_service</servlet-name>
+        <url-pattern>/siteMap/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>hyrax</servlet-name>
+        <url-pattern>/hyrax/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>adminInterface</servlet-name>
+        <url-pattern>/hai/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>viewers</servlet-name>
+        <url-pattern>/viewers/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>docs_servlet</servlet-name>
+        <url-pattern>/docs/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>aggregation</servlet-name>
+        <url-pattern>/aggregation/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>w10n</servlet-name>
+        <url-pattern>/w10n/*</url-pattern>
+    </servlet-mapping>
+    
+    <servlet-mapping>
+        <servlet-name>wcs</servlet-name>
+        <url-pattern>/wcs/*</url-pattern>
+    </servlet-mapping>
+
+    <!-- ==================== Default Session Configuration ================= -->
+  <!-- You can set the default session timeout (in minutes) for all newly   -->
+  <!-- created sessions by modifying the value below.                       -->
+
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
+
+    <!-- Default Error Page Definitions -->
+    <error-page>
+        <error-code>400</error-code>
+        <location>/error/error400.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>401</error-code>
+        <location>/error/error401.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>403</error-code>
+        <location>/error/error403.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>404</error-code>
+        <location>/error/error404.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>406</error-code>
+        <location>/error/error406.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>418</error-code>
+        <location>/error/error418.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>500</error-code>
+        <location>/error/error500.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>501</error-code>
+        <location>/error/error501.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>502</error-code>
+        <location>/error/error502.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>504</error-code>
+        <location>/error/error504.jsp</location>
+    </error-page>
+    <error-page>
+        <exception-type>java.lang.Throwable</exception-type>
+        <location>/error/error500.jsp</location>
+    </error-page>
+
+
+
+  <!-- ===================== Default MIME Type Mappings =================== -->
+  <!-- When serving static resources, Tomcat will automatically generate    -->
+  <!-- a "Content-Type" header based on the resource's filename extension,  -->
+  <!-- based on these mappings.  Additional mappings can be added here to   -->
+  <!-- apply to  your own application's web.xml deployment descriptor.      -->
+
+
+    <welcome-file-list>
+        <welcome-file>index.jsp</welcome-file>
+        <welcome-file>index.html</welcome-file>
+        <welcome-file>index.htm</welcome-file>
+    </welcome-file-list>
+
+
+
+    <!-- Define a Security Constraint on the Admin command and user interfaces -->
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Hyrax Admin Interface</web-resource-name>
+            <url-pattern>/hai/*</url-pattern>
+            <url-pattern>/admin/*</url-pattern>
+        </web-resource-collection>
+
+        <auth-constraint>
+            <role-name>manager</role-name>
+        </auth-constraint>
+
+        <user-data-constraint>
+            <!-- this ensures that all efforts to access the admin interface nd resources must use HTTPS -->
+            <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+            <!-- transport-guarantee>NONE</transport-guarantee -->
+        </user-data-constraint>
+    </security-constraint>
+
+    <!-- Define the Login Configuration for this Application -->
+
+    <login-config>
+        <auth-method>FORM</auth-method>
+        <realm-name>Hyrax Administration Pages</realm-name>
+        <form-login-config>
+            <form-login-page>/admin/jsp/login.jsp</form-login-page>
+            <form-error-page>/admin/jsp/login-failed.jsp</form-error-page>
+        </form-login-config>
+    </login-config>
+
+
+    <!-- Security roles referenced by this web application -->
+    <security-role>
+        <description>
+            The role that is required to login to the Hyrax Administration Application
+        </description>
+        <role-name>manager</role-name>
+    </security-role>
+
+
+</web-app>
+
+
+

--- a/src/opendap/ngap/NgapServlet.java
+++ b/src/opendap/ngap/NgapServlet.java
@@ -1,0 +1,4 @@
+package opendap.ngap;
+
+public class NgapServlet {
+}

--- a/src/opendap/ngap/NgapServlet.java
+++ b/src/opendap/ngap/NgapServlet.java
@@ -1,4 +1,0 @@
-package opendap.ngap;
-
-public class NgapServlet {
-}


### PR DESCRIPTION
This PR adds:

- A customized `web.xml` for NGAP that by default enables authentication.
- A customized `urlrewrite.xml` that routes all traffic not specifically
  destined for one of the various service endpoints (hyrax, wcs, etc)
  to the NGAP service endpoint. 
- A new build target for the NGAP service (`ant ngap`) that utilizes the above to
  build a ROOT.war file for deployment into the root (aka `/`) context
  for Tomcat.

The upshot is that as long as the first path component in the NGAP resty path (currently providers) does not conflict with one of the Hyrax services named in the urlrewrite.xml file all of the NGAP traffic will be correctly routed to the NGAP service.

Previously the the NGAP service was accessible only at:
```
http://HOSTNAME/hyrax/ngap/providers/...
```
Now, in addition to the above, the service can be invoked like this:
```
http://HOSTNAME/providers/...
```
