### PR TITLE
Json ld patch

### DIFF
--- a/src/opendap/bes/dap2Responders/Dap2IFH.java
+++ b/src/opendap/bes/dap2Responders/Dap2IFH.java
@@ -198,6 +198,8 @@ public class Dap2IFH extends Dap4Responder {
         String name  = dataset.getAttributeValue("name");
         sb.append(indent).append("\"name\": \"").append(name).append("\",\n");
 
+        String description = "No description available.";
+        sb.append(indent).append("\"description\": \"").append(description).append("\",\n");
 
         Attribute xmlBase  = dataset.getAttribute("base", Namespace.XML_NAMESPACE);
         String datasetUrl;

--- a/src/opendap/bes/dap2Responders/Dap2IFH.java
+++ b/src/opendap/bes/dap2Responders/Dap2IFH.java
@@ -56,6 +56,7 @@ import org.slf4j.Logger;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.DataOutputStream;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Vector;
 
@@ -198,7 +199,7 @@ public class Dap2IFH extends Dap4Responder {
         String name  = dataset.getAttributeValue("name");
         sb.append(indent).append("\"name\": \"").append(name).append("\",\n");
 
-        String description = "No description available. No description available.";
+        String description = getBestDescription(dataset);
         sb.append(indent).append("\"description\": \"").append(description).append("\",\n");
 
         Attribute xmlBase  = dataset.getAttribute("base", Namespace.XML_NAMESPACE);
@@ -392,32 +393,79 @@ public class Dap2IFH extends Dap4Responder {
         return sb.toString();
     }
 
+    String getStringAttrValue(Element e, String target_name){
+        List<Element> dataset_attributes = e.getContent(attributeFilter);
+        for (Element attr: dataset_attributes) {
 
-    /*
-    public String attributeToPropertyValue_OLD(Element attribute, String indent){
-        StringBuilder sb = new StringBuilder();
-        List<Element> values = attribute.getChildren("value",DAP.DAPv32_NS);
+            String type = e.getAttributeValue("type");
+            if (type == null) type = "";
 
-        if(!values.isEmpty()){
-            sb.append(indent).append("{\n");
-            sb.append(indent).append(indent_inc).append("\"@type\": \"PropertyValue\", \n");
-            sb.append(indent).append(indent_inc).append("\"name\": \"").append(attribute.getAttributeValue("name")).append("\", \n");
+            String name = e.getAttributeValue("name");
+            if (name == null) name = "";
 
-            boolean first = true;
-            for(Element value : values){
-                if(!first)
-                    sb.append(",\n");
-                sb.append(indent).append(indent_inc).append("\"value\": \"").append(value.getTextTrim()).append("\"");
-                first = false;
+            if(type.equalsIgnoreCase("string") && name.equalsIgnoreCase(target_name)){
+                Element valueElement = attr.getChild("Value",DAP.DAPv32_NS);
+                if(valueElement!=null){
+                    return valueElement.getTextTrim();
+                }
             }
-            sb.append("\n");
-            sb.append(indent).append("}");
         }
-        return sb.toString();
+        return null;
     }
 
-*/
 
+    public String getBestDescription(Element dapObj) {
+        String bestDescription  = getDescription(dapObj);
+        if(bestDescription==null){
+            bestDescription = "The dataset contains no obvious metadata " +
+                    "that might be used as a description.";
+        }
+
+        while(bestDescription.length()<55)
+            bestDescription += " ";
+
+        return bestDescription;
+    }
+
+
+    private  String getDescription(Element dapObj){
+        String candidate = null;
+
+        List<Element> dataset_attributes = dapObj.getContent(attributeFilter);
+        Iterator<Element> itr = dataset_attributes.iterator();
+        while (itr.hasNext() && candidate==null){
+            Element attrElement = itr.next();
+
+            String type = attrElement.getAttributeValue("type");
+            if(type==null) type="";
+
+            String name = attrElement.getAttributeValue("name");
+            if(name==null) name="";
+
+
+            if(type.equalsIgnoreCase("container")){
+                // Then we recurse....
+                candidate = getDescription(attrElement);
+            }
+            else if(type.equalsIgnoreCase("string")){
+                // We only care about string valued attributes for a description...
+
+                String value = null;
+                Element valueElement = attrElement.getChild("Value",DAP.DAPv32_NS);
+                if(valueElement!=null)
+                    value = valueElement.getTextTrim();
+
+                if(name.equalsIgnoreCase("description")){
+                    candidate = value;
+                }
+                else if(name.equalsIgnoreCase("title")){
+                    candidate = value;
+                }
+            }
+        }
+
+        return candidate;
+    }
 
 
 }

--- a/src/opendap/bes/dap2Responders/Dap2IFH.java
+++ b/src/opendap/bes/dap2Responders/Dap2IFH.java
@@ -198,7 +198,7 @@ public class Dap2IFH extends Dap4Responder {
         String name  = dataset.getAttributeValue("name");
         sb.append(indent).append("\"name\": \"").append(name).append("\",\n");
 
-        String description = "No description available.";
+        String description = "No description available. No description available.";
         sb.append(indent).append("\"description\": \"").append(description).append("\",\n");
 
         Attribute xmlBase  = dataset.getAttribute("base", Namespace.XML_NAMESPACE);

--- a/src/opendap/bes/dap2Responders/Dap2IFH.java
+++ b/src/opendap/bes/dap2Responders/Dap2IFH.java
@@ -421,6 +421,10 @@ public class Dap2IFH extends Dap4Responder {
                     "that might be used as a description.";
         }
 
+
+        if(bestDescription.length()>500)
+            bestDescription = bestDescription.substring(0,498);
+
         while(bestDescription.length()<55)
             bestDescription += " ";
 

--- a/src/opendap/bes/dap2Responders/Dap2IFH.java
+++ b/src/opendap/bes/dap2Responders/Dap2IFH.java
@@ -451,7 +451,7 @@ public class Dap2IFH extends Dap4Responder {
                 // We only care about string valued attributes for a description...
 
                 String value = null;
-                Element valueElement = attrElement.getChild("Value",DAP.DAPv32_NS);
+                Element valueElement = attrElement.getChild("value",DAP.DAPv32_NS);
                 if(valueElement!=null)
                     value = valueElement.getTextTrim();
 

--- a/src/opendap/bes/dap2Responders/Dap2IFH.java
+++ b/src/opendap/bes/dap2Responders/Dap2IFH.java
@@ -199,7 +199,7 @@ public class Dap2IFH extends Dap4Responder {
         String name  = dataset.getAttributeValue("name");
         sb.append(indent).append("\"name\": \"").append(name).append("\",\n");
 
-        String description = getBestDescription(dataset);
+        String description = getDatasetSearchDescription(dataset,attributeFilter);
         sb.append(indent).append("\"description\": \"").append(description).append("\",\n");
 
         Attribute xmlBase  = dataset.getAttribute("base", Namespace.XML_NAMESPACE);
@@ -393,29 +393,9 @@ public class Dap2IFH extends Dap4Responder {
         return sb.toString();
     }
 
-    String getStringAttrValue(Element e, String target_name){
-        List<Element> dataset_attributes = e.getContent(attributeFilter);
-        for (Element attr: dataset_attributes) {
 
-            String type = e.getAttributeValue("type");
-            if (type == null) type = "";
-
-            String name = e.getAttributeValue("name");
-            if (name == null) name = "";
-
-            if(type.equalsIgnoreCase("string") && name.equalsIgnoreCase(target_name)){
-                Element valueElement = attr.getChild("Value",DAP.DAPv32_NS);
-                if(valueElement!=null){
-                    return valueElement.getTextTrim();
-                }
-            }
-        }
-        return null;
-    }
-
-
-    public String getBestDescription(Element dapObj) {
-        String bestDescription  = getDescription(dapObj);
+    public static String getDatasetSearchDescription(Element dapObj, Filter attrFilter) {
+        String bestDescription  = getDescription(dapObj, attrFilter);
         if(bestDescription==null){
             bestDescription = "The dataset contains no obvious metadata " +
                     "that might be used as a description.";
@@ -432,10 +412,10 @@ public class Dap2IFH extends Dap4Responder {
     }
 
 
-    private  String getDescription(Element dapObj){
+    private static String getDescription(Element dapObj, Filter attrFilter){
         String candidate = null;
 
-        List<Element> dataset_attributes = dapObj.getContent(attributeFilter);
+        List<Element> dataset_attributes = dapObj.getContent(attrFilter);
         Iterator<Element> itr = dataset_attributes.iterator();
         while (itr.hasNext() && candidate==null){
             Element attrElement = itr.next();
@@ -449,7 +429,7 @@ public class Dap2IFH extends Dap4Responder {
 
             if(type.equalsIgnoreCase("container")){
                 // Then we recurse....
-                candidate = getDescription(attrElement);
+                candidate = getDescription(attrElement, attrFilter);
             }
             else if(type.equalsIgnoreCase("string")){
                 // We only care about string valued attributes for a description...

--- a/src/opendap/bes/dap4Responders/DatasetMetadata/HtmlDMR.java
+++ b/src/opendap/bes/dap4Responders/DatasetMetadata/HtmlDMR.java
@@ -30,6 +30,7 @@ import opendap.PathBuilder;
 import opendap.auth.AuthenticationControls;
 import opendap.bes.Version;
 import opendap.bes.dap2Responders.BesApi;
+import opendap.bes.dap2Responders.Dap2IFH;
 import opendap.bes.dap4Responders.Dap4Responder;
 import opendap.bes.dap4Responders.MediaType;
 import opendap.coreServlet.OPeNDAPException;
@@ -55,6 +56,7 @@ import org.slf4j.Logger;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.DataOutputStream;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Vector;
 
@@ -190,6 +192,8 @@ public class HtmlDMR extends Dap4Responder {
         String name  = dataset.getAttributeValue("name");
         sb.append(indent).append("\"name\": \"").append(name).append("\",\n");
 
+        String description =Dap2IFH.getDatasetSearchDescription(dataset,dap4AttributeFilter);
+        sb.append(indent).append("\"description\": \"").append(description).append("\",\n");
 
         Attribute xmlBase  = dataset.getAttribute("base", Namespace.XML_NAMESPACE);
         String datasetUrl;
@@ -399,6 +403,7 @@ public class HtmlDMR extends Dap4Responder {
         }
         return sb.toString();
     }
+
 
 
 }


### PR DESCRIPTION
This patch adds a required description element to the JSON-LD  Dataset response. The value is required to be between 50 and 500 characters. This change adds code that inspects top level attributes and attribute containers for dap Attributes whose name is either description or title,  using the value of the first such that it encounters.