### PR TITLE
Force current URL protocol on download URLs

### DIFF
--- a/resources/hyrax/js/dap2_buttons.js
+++ b/resources/hyrax/js/dap2_buttons.js
@@ -4,20 +4,22 @@ function make_a_selection(){
 }
 
 function getAs_button_action(type_name, suffix) {
-    var url = new String(document.forms[0].url.value);
-
-    var url_parts = url.split("?");
+    let currentUrl = new URL(window.location.href);
+    let downloadUrl = new URL(document.forms[0].url.value);
+ 
     /* handle case where constraint is null. */
-    if (url_parts[1] != null && url_parts[1].length>0) {
-        var get_as_url = url_parts[0] + suffix + "?" + url_parts[1];
-    } else if(enforce_selection) {
+    if (downloadUrl.search.length === 0 && enforce_selection) {
         make_a_selection();
         return;
     }
-    else {
-        var get_as_url = url_parts[0] +  suffix + "?";
-    }
-    window.open(encodeURI(get_as_url),type_name);
+    
+    // force the current protocol on the download url
+    downloadUrl.protocol = currentUrl.protocol;
+
+    // append suffix
+    downloadUrl.pathname += suffix;  
+       
+    window.open(downloadUrl.toString(), type_name);
 }
 
 var help = 0;


### PR DESCRIPTION
This addresses a [mixed-content policy](https://blog.chromium.org/2020/02/protecting-users-from-insecure.html) issue when the site is hosted via HTTPS but OPeNDAP is hosted under an insecure (http) reverse proxy.  When deployed in this scenario, OPeNDAP generates insecure URLs when it should be generating https.  Chrome recently started to block these which is why we just started to notice it.  

>Mixed Content: The site at 'https://example.com/' was loaded over a secure connection, but the file at >'https://example.com/opendap/Florence/Covered%2520Data%2520Snapshots/5/NDBC%2520Standard%2520Meteorological%2520data/32012h2018.nc.nc?>time%5B0:1:2353%5D,latitude%5B0:1:0%5D' was redirected through an insecure connection. This file should be served over HTTPS. This download has been blocked. See >https://blog.chromium.org/2020/02/protecting-users-from-insecure.html for more details.

This solution is to simply force the current URL protocol on the download links.