### PR TITLE
Apparently FileDispatchHandler is not actually ready to be deprecated.

### DIFF
--- a/src/opendap/bes/FileDispatchHandler.java
+++ b/src/opendap/bes/FileDispatchHandler.java
@@ -57,7 +57,6 @@ import java.util.Date;
  * Provides access to files held in the BES that the BES does not recognize as data.
  *
  */
-@Deprecated
 public class FileDispatchHandler implements DispatchHandler {
 
     private org.slf4j.Logger log;

--- a/src/opendap/coreServlet/DispatchServlet.java
+++ b/src/opendap/coreServlet/DispatchServlet.java
@@ -353,7 +353,7 @@ public class DispatchServlet extends HttpServlet {
             httpGetHandlers.add(new opendap.bes.BESThreddsDispatchHandler());
         }
 
-        // httpGetHandlers.add(new opendap.bes.FileDispatchHandler());
+        httpGetHandlers.add(new opendap.bes.FileDispatchHandler());
 
         for (DispatchHandler dh : httpGetHandlers) {
             dh.init(this, config);


### PR DESCRIPTION
Last July (7/29/21) I deprecated the FileDispatchHandler and dropped its usage from the coreServlet/DispatchServlet class. It seems this was a misguided action that broke the server's ability to transmit BES file system files that the BES does not identify as data. This PR corrects this mistake and restores the functionality