### PR TITLE
Throw IOException if reading from socket returns -1

### DIFF
--- a/src/opendap/io/Chunk.java
+++ b/src/opendap/io/Chunk.java
@@ -193,6 +193,11 @@ public class Chunk {
                     if (totalBytesRead == 0)
                         totalBytesRead = -1;
                     done = true;
+
+                    String msg = "Socket Read Exception: Attempted to read "+len+" bytes starting " +
+                            "at "+off+" into a buffer of length "+buf.length+" ";
+                    log.error(msg);
+                    throw new IOException(msg);
                 }
                 else {
                     totalBytesRead += bytesRead;


### PR DESCRIPTION
Throwing IOException when reading from socket returns -1.