### PR TITLE
First attempt to streamline the EDL token handling

### DIFF
--- a/src/opendap/auth/IdProvider.java
+++ b/src/opendap/auth/IdProvider.java
@@ -35,11 +35,12 @@ import javax.servlet.http.HttpSession;
 import java.io.IOException;
 
 /**
- * Created by ndp on 9/24/14.
+ * Base class for the ID Provider implementations.
  */
 public abstract class IdProvider {
 
 
+    public static final String AUTHORIZATION_HEADER_KEY="authorization";
     protected String authContext;
     private String description;
     protected String serviceContext;

--- a/src/opendap/logging/Timer.java
+++ b/src/opendap/logging/Timer.java
@@ -174,9 +174,16 @@ public class Timer {
      * @return A summary of the current timing activities since the last call to Timer.reset()
      */
     public static String report() {
-        if (!enabled.get())
-            return "Timer is NOT enabled";
-
+        if (!enabled.get()) {
+            Date now = new Date();
+            StringBuilder sb = new StringBuilder();
+            sb.append("[");
+            sb.append(now.getTime()).append(mrk);
+            sb.append(Thread.currentThread().getName()).append(mrk);
+            sb.append("Timer is NOT enabled for this Thread.");
+            sb.append("]\n");
+            return sb.toString();
+        }
         return getThreadLog().toString();
     }
 }


### PR DESCRIPTION
Goals:
* Eliminate redirects
* Eliminate the need for the client to maintain a session.

When I started I needed to access a data response from Hyrax using cURL like this:
```
curl -L -c cookie -b cookie -H "${auth_hdr}" "http://localhost:8080/opendap/data/nc/fnoc1.nc.dds"
```
After this modification I can successfully make the same request like this:
```
curl -H "${auth_hdr}" "http://localhost:8080/opendap/data/nc/fnoc1.nc.dds"
```
