### PR TITLE
Edl patch

### DIFF
--- a/src/opendap/auth/UrsIdP.java
+++ b/src/opendap/auth/UrsIdP.java
@@ -243,8 +243,23 @@ public class UrsIdP extends IdProvider{
         return uid;
     }
 
+    /**
+     * Builds the EDL returnTo URL. By using the URL returned by
+     * ReqInfo.getRequestUrlPath() we capitalize on the work done inside to
+     * sort out the correct request scheme/protocol.
+     * @param request The request to assess
+     * @return The EDL redirect_uri parameter value for the EDL authorization
+     * redirect being built for the requesting client.
+     */
+    private String getEdlRedirectUri(HttpServletRequest request){
+        String edlRedirectUrl =  ReqInfo.getRequestUrlPath(request);
+        edlRedirectUrl = edlRedirectUrl.substring(0,edlRedirectUrl.indexOf("/",9));
+        edlRedirectUrl += getLoginEndpoint();
+        return edlRedirectUrl;
+    }
 
     /**
+     *
      * Performs the user login operations.
      * This method does not actually generate any output. It performs a series
      * of redirects, depending upon the current state.
@@ -314,18 +329,11 @@ public class UrsIdP extends IdProvider{
             // redirect the user to URS to start the authentication process.
             String code = request.getParameter("code");
             if (code == null) {
-                //String url = getUrsUrl() + "/oauth/authorize?client_id=" + getUrsClientAppId() +
-                //   "&response_type=code&redirect_uri=" + request.getRequestURL();
-                // request.getRequestURL(); // TODO: REMOVE THIS LINE BEFORE COMMIT
-
                 String url;
                 url = PathBuilder.pathConcat(getUrsUrl(), "/oauth/authorize?");
                 url += "client_id=" + getUrsClientAppId();
-                url += "&";
-
-                String returnToUrl = ReqInfo.getRequestUrlPath(request);
-
-                url += "response_type=code&redirect_uri=" + returnToUrl;
+                url += "&response_type=code";
+                url += "&redirect_uri=" + getEdlRedirectUri(request);
 
                 log.info("Redirecting client to URS SSO. URS Code Request URL: {}", LogUtil.scrubEntry(url));
                 response.sendRedirect(url);

--- a/src/opendap/coreServlet/ReqInfo.java
+++ b/src/opendap/coreServlet/ReqInfo.java
@@ -51,7 +51,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static opendap.http.Util.PROTOCOL_TERMINATON;
+import static opendap.http.Util.PROTOCOL_TERMINATION;
 
 
 /**
@@ -864,11 +864,11 @@ public class ReqInfo {
             }
         }
         // We know that the values of the request headers CLOUD_FRONT_FORWARDED_PROTOCOL
-        // and X_FORWARDED_PROTOCOL don't end with the PROTOCOL_TERMINATON (aka "://")
-        // zso we check for the abscence of a trailing PROTOCOL_TERMINATON and add it
+        // and X_FORWARDED_PROTOCOL don't end with the PROTOCOL_TERMINATION (aka "://")
+        // zso we check for the absence of a trailing PROTOCOL_TERMINATION and add it
         // as needed.
-        if(!client_request_protcol.endsWith(PROTOCOL_TERMINATON)){
-            client_request_protcol += PROTOCOL_TERMINATON;
+        if(!client_request_protcol.endsWith(PROTOCOL_TERMINATION)){
+            client_request_protcol += PROTOCOL_TERMINATION;
         }
 
         // Determine which server port the client was accessing.
@@ -897,7 +897,7 @@ public class ReqInfo {
             requestUrlStr = req.getRequestURL().toString();
             if(!requestUrlStr.startsWith(client_request_protcol)){
                 // If protocols do not match then update the requestUrlStr to match client_request_protcol
-                int index = requestUrlStr.indexOf(PROTOCOL_TERMINATON) + PROTOCOL_TERMINATON.length();
+                int index = requestUrlStr.indexOf(PROTOCOL_TERMINATION) + PROTOCOL_TERMINATION.length();
                 requestUrlStr = client_request_protcol + requestUrlStr.substring(index);
             }
         }

--- a/src/opendap/http/Util.java
+++ b/src/opendap/http/Util.java
@@ -48,7 +48,7 @@ import java.io.OutputStream;
 
 public class Util {
 
-    public static final String PROTOCOL_TERMINATON = "://";
+    public static final String PROTOCOL_TERMINATION = "://";
     public static final String HTTP_PROTOCOL = "http://";
     public static final String HTTPS_PROTOCOL = "https://";
     public static final String BES_PROTOCOL = "bes://";


### PR DESCRIPTION
Fixes incorrect construction of the EDL `redirect_uri` query parameter used in the authorization redirect returned to unauthenticated clients.