### PR TITLE
Refactored RequestCache for request id support.

### DIFF
--- a/resources/hyrax/admin/jsp/besctl.jsp
+++ b/resources/hyrax/admin/jsp/besctl.jsp
@@ -40,7 +40,7 @@
 <%
 
     Logger log = LoggerFactory.getLogger("JavaServerPages");
-    RequestCache.openThreadCache();
+    RequestCache.open(request);
 
     String contextPath = request.getContextPath();
     log.debug("besctl.jsp -  contextPath: "+contextPath);
@@ -718,5 +718,5 @@
 </body>
 </html>
 <%
-    RequestCache.closeThreadCache();
+    RequestCache.close();
 %>

--- a/resources/hyrax/admin/jsp/olfsLogView.jsp
+++ b/resources/hyrax/admin/jsp/olfsLogView.jsp
@@ -37,7 +37,7 @@
 <%
 
     Logger log = LoggerFactory.getLogger("JavaServerPages");
-    RequestCache.openThreadCache();
+    RequestCache.open(request);
 
     String contextPath = request.getContextPath();
     log.debug("olfsLogView.jsp -  contextPath: "+contextPath);
@@ -200,5 +200,5 @@
 </body>
 </html>
 <%
-    RequestCache.closeThreadCache();
+    RequestCache.close();
 %>

--- a/src/opendap/aggregation/AggregationServlet.java
+++ b/src/opendap/aggregation/AggregationServlet.java
@@ -531,7 +531,7 @@ public class AggregationServlet extends HttpServlet {
             TransmitCoordinator tc = new ServletResponseTransmitCoordinator(response);
             ServletOutputStream out = response.getOutputStream();
 
-            RequestCache.openThreadCache();
+            RequestCache.open(request);
 
             String requestKind = Scrub.simpleString(request.getParameter("operation"));
             if (requestKind == null)
@@ -568,7 +568,7 @@ public class AggregationServlet extends HttpServlet {
             logError(t, "in doGet():");
         }
         finally {
-            RequestCache.closeThreadCache();
+            RequestCache.close();
         }
 
     }
@@ -602,7 +602,7 @@ public class AggregationServlet extends HttpServlet {
         log.debug("doHead() - BEGIN");
 
         try {
-            RequestCache.openThreadCache();
+            RequestCache.open(request);
             ServletOutputStream out = response.getOutputStream();
 
             String requestKind = Scrub.simpleString(request.getParameter("operation"));
@@ -644,7 +644,7 @@ public class AggregationServlet extends HttpServlet {
             logError(t, "in doHead():");
         }
         finally {
-            RequestCache.closeThreadCache();
+            RequestCache.close();
         }
 
 

--- a/src/opendap/auth/IdFilter.java
+++ b/src/opendap/auth/IdFilter.java
@@ -173,12 +173,13 @@ public class IdFilter implements Filter {
         }
 
         try {
-            RequestCache.openThreadCache();
 
             HttpServletRequest request = (HttpServletRequest) sreq;
+            RequestCache.open(request);
+            String requestId = RequestCache.getRequestId();
+
             HttpServletRequest hsReq = request;
 
-            String requestId = this.getClass().getName()+"-" + counter.incrementAndGet();
             ServletLogUtil.logServerAccessStart(request,logName,request.getMethod(), requestId);
             // Get session, make new as needed.
             HttpSession session = hsReq.getSession(true);
@@ -354,7 +355,7 @@ public class IdFilter implements Filter {
             ServletLogUtil.logServerAccessEnd(200,logName);
         }
         finally {
-            RequestCache.closeThreadCache();
+            RequestCache.close();
         }
     }
 

--- a/src/opendap/auth/PDPService.java
+++ b/src/opendap/auth/PDPService.java
@@ -125,6 +125,8 @@ public class PDPService extends HttpServlet {
 
         } finally {
             ServletLogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, ServletLogUtil.PDP_SERVICE_LAST_MODIFIED_LOG_ID);
+            // We don't RequestCache.close() here so that the cache is
+            // available for the doGet() method which comes next.
         }
     }
 

--- a/src/opendap/auth/PDPService.java
+++ b/src/opendap/auth/PDPService.java
@@ -119,9 +119,8 @@ public class PDPService extends HttpServlet {
     @Override
     protected long getLastModified(HttpServletRequest req) {
         try {
-            RequestCache.openThreadCache();
-            long reqno = REQ_NUMBER.incrementAndGet();
-            ServletLogUtil.logServerAccessStart(req, ServletLogUtil.PDP_SERVICE_LAST_MODIFIED_LOG_ID, "LastModified", Long.toString(reqno));
+            RequestCache.open(req);
+            ServletLogUtil.logServerAccessStart(req, ServletLogUtil.PDP_SERVICE_LAST_MODIFIED_LOG_ID, "LastModified", RequestCache.getRequestId());
             return new Date().getTime();
 
         } finally {
@@ -163,9 +162,9 @@ public class PDPService extends HttpServlet {
         String msg = "";
         int status = HttpServletResponse.SC_FORBIDDEN;
 
-        RequestCache.openThreadCache();
+        RequestCache.open(request);
 
-        ServletLogUtil.logServerAccessStart(request, ServletLogUtil.PDP_SERVICE_ACCESS_LOG_ID, request.getMethod(), Integer.toString(REQ_NUMBER.incrementAndGet()));
+        ServletLogUtil.logServerAccessStart(request, ServletLogUtil.PDP_SERVICE_ACCESS_LOG_ID, request.getMethod(), RequestCache.getRequestId());
         try {
             if (!redirect(request, response)) {
 
@@ -227,7 +226,7 @@ public class PDPService extends HttpServlet {
         }
         finally {
             ServletLogUtil.logServerAccessEnd(status, ServletLogUtil.PDP_SERVICE_ACCESS_LOG_ID);
-            RequestCache.closeThreadCache();
+            RequestCache.close();
         }
     }
 

--- a/src/opendap/auth/PEPFilter.java
+++ b/src/opendap/auth/PEPFilter.java
@@ -41,7 +41,6 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.File;
 import java.io.IOException;
-import java.security.Principal;
 
 
 /**
@@ -136,10 +135,11 @@ public class PEPFilter implements Filter {
         }
         try {
 
-            RequestCache.openThreadCache();
 
 
             HttpServletRequest  hsReq = (HttpServletRequest)  request;
+            RequestCache.open(hsReq);
+
             HttpServletResponse hsRes = (HttpServletResponse) response;
 
             // If they are authenticated then we should be able to get the remoteUser() or UserPrinciple
@@ -197,7 +197,7 @@ public class PEPFilter implements Filter {
             throw new ServletException(e.getMessage(),e);
         }
         finally{
-            RequestCache.closeThreadCache();
+            RequestCache.close();
 
         }
 

--- a/src/opendap/auth/PEPFilter.java
+++ b/src/opendap/auth/PEPFilter.java
@@ -198,7 +198,6 @@ public class PEPFilter implements Filter {
         }
         finally{
             RequestCache.close();
-
         }
 
     }

--- a/src/opendap/bes/BESSiteMapService.java
+++ b/src/opendap/bes/BESSiteMapService.java
@@ -65,7 +65,7 @@ public class BESSiteMapService extends HttpServlet {
             ServletLogUtil.initLogging(this);
             LOG.debug("init() start");
             // Timer.enable();
-            RequestCache.openThreadCache();
+            // RequestCache.openThreadCache();
 
 
             _dapServiceContext = getInitParameter("DapServiceContext");
@@ -101,7 +101,7 @@ public class BESSiteMapService extends HttpServlet {
             IS_INITIALIZED.set(true);
 
             LOG.info("init() complete.");
-            RequestCache.closeThreadCache();
+            // RequestCache.closeThreadCache();
         }
         finally {
             INIT_LOCK.unlock();
@@ -163,14 +163,14 @@ public class BESSiteMapService extends HttpServlet {
         int response_size = -1;
         try {
             Procedure timedProcedure = Timer.start();
-            RequestCache.openThreadCache();
+            RequestCache.open(request);
+            String reqId = RequestCache.getRequestId();
             try {
 
-                int reqno = REQ_NUMBER.incrementAndGet();
-                ServletLogUtil.logServerAccessStart(request, ServletLogUtil.SITEMAP_ACCESS_LOG_ID, "HTTP-GET", Long.toString(reqno));
+                ServletLogUtil.logServerAccessStart(request, ServletLogUtil.SITEMAP_ACCESS_LOG_ID, "HTTP-GET", reqId);
 
                 LOG.debug(Util.getMemoryReport());
-                LOG.debug(ServletUtil.showRequest(request, reqno));
+                LOG.debug(ServletUtil.showRequest(request, reqId));
                 LOG.debug(ServletUtil.probeRequest(this, request));
 
                 if (ReqInfo.isServiceOnlyRequest(request)) {
@@ -227,7 +227,7 @@ public class BESSiteMapService extends HttpServlet {
         }
         finally {
             ServletLogUtil.logServerAccessEnd(request_status, response_size, ServletLogUtil.SITEMAP_ACCESS_LOG_ID);
-            RequestCache.closeThreadCache();
+            RequestCache.close();
             LOG.info("Response completed.\n");
         }
         LOG.info("Timing Report: \n{}", Timer.report());

--- a/src/opendap/bes/BesApi.java
+++ b/src/opendap/bes/BesApi.java
@@ -31,6 +31,7 @@ import opendap.auth.EarthDataLoginAccessToken;
 import opendap.auth.UserProfile;
 import opendap.bes.caching.BesNodeCache;
 import opendap.coreServlet.ByteArrayOutputStreamTransmitCoordinator;
+import opendap.coreServlet.RequestCache;
 import opendap.coreServlet.ResourceInfo;
 import opendap.coreServlet.TransmitCoordinator;
 import opendap.dap.User;
@@ -2328,8 +2329,7 @@ public class BesApi implements Cloneable {
 
 
         Element e, request = new Element("request", BES_NS);
-        request.setAttribute(REQUEST_ID,getRequestIdBase());
-
+        request.setAttribute(REQUEST_ID, RequestCache.getRequestId());
 
         request.addContent(setContextElement(XDAP_ACCEPT_CONTEXT, DEFAULT_XDAP_ACCEPT));
 
@@ -2421,7 +2421,7 @@ public class BesApi implements Cloneable {
 
         Element e, request = new Element("request", BES_NS);
 
-        request.setAttribute(REQUEST_ID,getRequestIdBase());
+        request.setAttribute(REQUEST_ID, RequestCache.getRequestId());
 
         //----------------------------------------------------------------------
         // Added this bit for the cloudy dap experiment - ndp 1/19/17
@@ -2488,7 +2488,7 @@ public class BesApi implements Cloneable {
     public  Document getSiteMapRequestDocument(String sitePrefix) {
 
         Element request = new Element("request", BES_NS);
-        request.setAttribute(REQUEST_ID,getRequestIdBase());
+        request.setAttribute(REQUEST_ID, RequestCache.getRequestId());
 
         request.addContent(setContextElement(EXPLICIT_CONTAINERS_CONTEXT,"no"));
         request.addContent(setContextElement(ERRORS_CONTEXT,XML_ERRORS));
@@ -2537,7 +2537,7 @@ public class BesApi implements Cloneable {
 
 
         Element request = new Element("request", BES_NS);
-        request.setAttribute(REQUEST_ID,getRequestIdBase());
+        request.setAttribute(REQUEST_ID, RequestCache.getRequestId());
 
         request.addContent(setContextElement(EXPLICIT_CONTAINERS_CONTEXT,"no"));
         request.addContent(setContextElement(ERRORS_CONTEXT,XML_ERRORS));
@@ -2553,11 +2553,8 @@ public class BesApi implements Cloneable {
 
 
     public Element showPathInfoRequestElement(String resource) {
-        Element e;
         Element spi = new Element("showW10nPathInfo",BES_NS);
-
         spi.setAttribute("node", resource);
-
         return spi;
     }
 
@@ -2591,7 +2588,7 @@ public class BesApi implements Cloneable {
 
 
         Element e, request = new Element("request", BES_NS);
-        request.setAttribute(REQUEST_ID,getRequestIdBase());
+        request.setAttribute(REQUEST_ID, RequestCache.getRequestId());
         request.addContent(setContextElement(ERRORS_CONTEXT,XML_ERRORS));
 
         e = new Element(type,BES_NS);
@@ -2747,10 +2744,6 @@ public class BesApi implements Cloneable {
 
     }
 
-    private static String getRequestIdBase(){
-        return "[thread:"+Thread.currentThread().getName()+"-"+ Thread.currentThread().getId()+"]";
-    }
-
 
 
     public String getBesCombinedTypeMatch()
@@ -2859,7 +2852,7 @@ public class BesApi implements Cloneable {
     public static Document getShowBesKeyRequestDocument(String besKey) {
 
         Element request = new Element("request", BES_NS);
-        request.setAttribute(REQUEST_ID,getRequestIdBase());
+        request.setAttribute(REQUEST_ID, RequestCache.getRequestId());
         request.addContent(setContextElement(EXPLICIT_CONTAINERS_CONTEXT,"no"));
         request.addContent(setContextElement(ERRORS_CONTEXT,XML_ERRORS));
         request.addContent(showBesKeyRequestElement(besKey));

--- a/src/opendap/build_dmrpp/BuildDmrppServlet.java
+++ b/src/opendap/build_dmrpp/BuildDmrppServlet.java
@@ -170,6 +170,8 @@ public class BuildDmrppServlet extends HttpServlet {
         }
         finally {
             ServletLogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, ServletLogUtil.BUILD_DMRPP_LAST_MODIFIED_LOG_ID);
+            // We don't RequestCache.close() here so that the cache is
+            // available for the doGet() method which comes next.
         }
     }
 

--- a/src/opendap/build_dmrpp/BuildDmrppServlet.java
+++ b/src/opendap/build_dmrpp/BuildDmrppServlet.java
@@ -159,10 +159,9 @@ public class BuildDmrppServlet extends HttpServlet {
     @Override
     public long getLastModified(HttpServletRequest req) {
 
-        RequestCache.openThreadCache();
+        RequestCache.open(req);
 
-        long reqno = reqNumber.incrementAndGet();
-        ServletLogUtil.logServerAccessStart(req, ServletLogUtil.BUILD_DMRPP_LAST_MODIFIED_LOG_ID, "LastModified", Long.toString(reqno));
+        ServletLogUtil.logServerAccessStart(req, ServletLogUtil.BUILD_DMRPP_LAST_MODIFIED_LOG_ID, "LastModified", RequestCache.getRequestId());
         try {
             if (ReqInfo.isServiceOnlyRequest(req))
                 return new Date().getTime();
@@ -215,7 +214,7 @@ public class BuildDmrppServlet extends HttpServlet {
             }
         } finally {
             ServletLogUtil.logServerAccessEnd(request_status, ServletLogUtil.BUILD_DMRPP_ACCESS_LOG_ID);
-            RequestCache.closeThreadCache();
+            RequestCache.close();
         }
     }
 

--- a/src/opendap/coreServlet/DispatchServlet.java
+++ b/src/opendap/coreServlet/DispatchServlet.java
@@ -664,6 +664,8 @@ public class DispatchServlet extends HttpServlet {
         } finally {
             ServletLogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, ServletLogUtil.HYRAX_LAST_MODIFIED_ACCESS_LOG_ID);
             Timer.stop(timedProcedure);
+            // We don't RequestCache.close() here so that the cache is
+            // available for the doGet() method which comes next.
         }
         return lmt;
     }

--- a/src/opendap/coreServlet/DispatchServlet.java
+++ b/src/opendap/coreServlet/DispatchServlet.java
@@ -117,7 +117,7 @@ public class DispatchServlet extends HttpServlet {
 
             // Timer.enable()
 
-            RequestCache.openThreadCache();
+            // RequestCache.openRequestCache();
 
             log.debug("BEGIN");
 
@@ -172,7 +172,7 @@ public class DispatchServlet extends HttpServlet {
             } catch (Exception e) {
                 throw new ServletException(e);
             }
-            RequestCache.closeThreadCache();
+            // RequestCache.closeThreadCache();
             IS_INITIALIZED.set(true);
             log.info("END");
         } finally {
@@ -464,7 +464,8 @@ public class DispatchServlet extends HttpServlet {
         try {
             Procedure timedProcedure = Timer.start();
 
-            RequestCache.openThreadCache();
+            RequestCache.open(request);
+            String reqId = RequestCache.getRequestId();
 
             try {
 
@@ -473,15 +474,14 @@ public class DispatchServlet extends HttpServlet {
                     return;
                 }
 
-                int reqno = reqNumber.incrementAndGet();
-                ServletLogUtil.logServerAccessStart(request, ServletLogUtil.HYRAX_ACCESS_LOG_ID, "HTTP-GET", Long.toString(reqno));
+                ServletLogUtil.logServerAccessStart(request, ServletLogUtil.HYRAX_ACCESS_LOG_ID, "HTTP-GET", reqId);
 
                 if (redirectForServiceOnlyRequest(request, response))
                     return;
 
                 if (log.isDebugEnabled()) {
                     log.debug(Util.getMemoryReport());
-                    log.debug(ServletUtil.showRequest(request, reqno));
+                    log.debug(ServletUtil.showRequest(request, reqId));
                     log.debug(ServletUtil.probeRequest(this, request));
                     String msg = "Requested relative URL: '" + relativeUrl +
                             "' suffix: '" + ReqInfo.getRequestSuffix(request) +
@@ -520,7 +520,7 @@ public class DispatchServlet extends HttpServlet {
             }
         } finally {
             ServletLogUtil.logServerAccessEnd(request_status, ServletLogUtil.HYRAX_ACCESS_LOG_ID);
-            RequestCache.closeThreadCache();
+            RequestCache.close();
             log.info("Response completed.\n");
         }
 
@@ -561,14 +561,13 @@ public class DispatchServlet extends HttpServlet {
         try {
             try {
 
-                RequestCache.openThreadCache();
+                RequestCache.open(request);
+                String reqId = RequestCache.getRequestId();
 
-                int reqno = reqNumber.incrementAndGet();
-
-                ServletLogUtil.logServerAccessStart(request, ServletLogUtil.HYRAX_ACCESS_LOG_ID, "HTTP-POST", Long.toString(reqno));
+                ServletLogUtil.logServerAccessStart(request, ServletLogUtil.HYRAX_ACCESS_LOG_ID, "HTTP-POST", reqId);
 
                 if (log.isDebugEnabled()) {
-                    log.debug(ServletUtil.showRequest(request, reqno));
+                    log.debug(ServletUtil.showRequest(request, reqId));
                     String msg = "Requested relative URL: '" + relativeUrl +
                             "' suffix: '" + ReqInfo.getRequestSuffix(request) +
                             "' CE: '" + ReqInfo.getConstraintExpression(request) + "'";
@@ -603,7 +602,7 @@ public class DispatchServlet extends HttpServlet {
             }
         } finally {
             ServletLogUtil.logServerAccessEnd(httpStatus, ServletLogUtil.HYRAX_ACCESS_LOG_ID);
-            RequestCache.closeThreadCache();
+            RequestCache.close();
         }
     }
 
@@ -641,10 +640,8 @@ public class DispatchServlet extends HttpServlet {
     @Override
     protected long getLastModified(HttpServletRequest req) {
 
-        RequestCache.openThreadCache();
-
-        long reqno = reqNumber.incrementAndGet();
-        ServletLogUtil.logServerAccessStart(req, ServletLogUtil.HYRAX_LAST_MODIFIED_ACCESS_LOG_ID, "LastModified", Long.toString(reqno));
+        RequestCache.open(req);
+        ServletLogUtil.logServerAccessStart(req, ServletLogUtil.HYRAX_LAST_MODIFIED_ACCESS_LOG_ID, "LastModified", RequestCache.getRequestId());
 
         long lmt = new Date().getTime();
 

--- a/src/opendap/coreServlet/ReqInfo.java
+++ b/src/opendap/coreServlet/ReqInfo.java
@@ -42,10 +42,7 @@ import java.io.StringWriter;
 import java.net.URLDecoder;
 import java.text.FieldPosition;
 import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Enumeration;
-import java.util.Map;
-import java.util.SimpleTimeZone;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
@@ -927,6 +924,18 @@ public class ReqInfo {
         return requestUrlStr;
     }
 
+
+    public static String getRequestId(HttpServletRequest req){
+        String reqID;
+        reqID = req.getHeader("A-api-request-uuid");
+        if(reqID == null) {
+            UUID uuid = UUID.randomUUID();
+            reqID = Thread.currentThread().getName() +
+                    ":" + Thread.currentThread().getId() +
+                    ":" + uuid;
+        }
+        return reqID;
+    }
 
 }
 

--- a/src/opendap/coreServlet/RequestCache.java
+++ b/src/opendap/coreServlet/RequestCache.java
@@ -31,6 +31,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * User: ndp
@@ -51,6 +52,10 @@ public class RequestCache {
         cache = new ConcurrentHashMap<>();
     }
 
+    private static final ReentrantLock lock;
+    static {
+        lock = new ReentrantLock();
+    }
     //private static long maxCacheTime = 10000; // in milliseconds
 
     private static class CachedObj {
@@ -90,14 +95,6 @@ public class RequestCache {
             String reqId = ReqInfo.getRequestId(request);
             put(REQUEST_ID_KEY,reqId);
         }
-    }
-
-    public static String getRequestId(){
-        Object id = get(REQUEST_ID_KEY);
-        if(id != null){
-            return (String)id;
-        }
-        return null;
     }
 
     public static void close(){
@@ -145,6 +142,21 @@ public class RequestCache {
         }
         else {
             log.debug("No Document cached for key \""+ key+"\"");
+        }
+        return null;
+    }
+
+    /**
+     * Every request cache instance has some type of request id. See
+     * opendap.coreServlet.ReqInfo.getRequestId() for more on how that's
+     * handled.
+     *
+     * @return
+     */
+    public static String getRequestId(){
+        Object id = get(REQUEST_ID_KEY);
+        if(id != null){
+            return (String)id;
         }
         return null;
     }

--- a/src/opendap/coreServlet/ServletUtil.java
+++ b/src/opendap/coreServlet/ServletUtil.java
@@ -349,13 +349,13 @@ public class ServletUtil {
      * @param reqno The request number.
      * @return A string containing infformation about the passed HttpServletRequest req
      */
-    public static String showRequest(HttpServletRequest req, long reqno) {
+    public static String showRequest(HttpServletRequest req, String reqId) {
 
         StringBuilder sb = new StringBuilder();
 
         sb.append("\n-------------------------------------------\n");
         sb.append("showRequest()\n");
-        sb.append("  Request #").append(reqno).append("\n");
+        sb.append("  RequestId: ").append(reqId).append("\n");
         sb.append("  HttpServletRequest Object:\n");
         sb.append("    getServerName():          ").append(req.getServerName()).append("\n");
         sb.append("    getServerPort():          ").append(req.getServerPort()).append("\n");

--- a/src/opendap/dap/User.java
+++ b/src/opendap/dap/User.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
+import java.util.UUID;
 
 /**
  * Created by IntelliJ IDEA.
@@ -47,9 +48,9 @@ import javax.servlet.http.HttpSession;
  */
 public class User {
 
-    private Logger log;
+    private final Logger log;
     private UserProfile userProfile;
-    private HttpServletRequest request;
+    private final HttpServletRequest request;
 
 
     public User(HttpServletRequest req){
@@ -98,4 +99,6 @@ public class User {
             return 0;
         }
     }
+
+
 }

--- a/src/opendap/gateway/BesGatewayApi.java
+++ b/src/opendap/gateway/BesGatewayApi.java
@@ -32,6 +32,7 @@ import opendap.bes.BadConfigurationException;
 import opendap.bes.BesApi;
 import opendap.coreServlet.OPeNDAPException;
 import opendap.coreServlet.ReqInfo;
+import opendap.coreServlet.RequestCache;
 import opendap.coreServlet.Util;
 import opendap.dap.User;
 import opendap.dap4.QueryParameters;
@@ -129,9 +130,7 @@ public class BesGatewayApi extends BesApi implements Cloneable {
         log.debug("Building request for BES gateway_module request. remoteDataSourceUrl: "+ remoteDataSourceUrl);
         Element e, request = new Element("request", BES.BES_NS);
 
-        String reqID = "["+Thread.currentThread().getName()+":"+
-                Thread.currentThread().getId()+":gateway_request]";
-        request.setAttribute("reqID",reqID);
+        request.setAttribute(REQUEST_ID, RequestCache.getRequestId());
 
 
         request.addContent(setContextElement(EXPLICIT_CONTAINERS_CONTEXT,"no"));
@@ -196,10 +195,7 @@ public class BesGatewayApi extends BesApi implements Cloneable {
 
         //String besDataSource = getBES(dataSource).trimPrefix(dataSource);
 
-        String reqID = Thread.currentThread().getName()+":"+ Thread.currentThread().getId();
-
-
-        request.setAttribute("reqID",reqID);
+        request.setAttribute(REQUEST_ID, RequestCache.getRequestId());
 
         /**----------------------------------------------------------------------
          * Added this bit for the cloudy dap experiment - ndp 1/19/17

--- a/src/opendap/gateway/DispatchServlet.java
+++ b/src/opendap/gateway/DispatchServlet.java
@@ -150,10 +150,8 @@ public class DispatchServlet extends HttpServlet {
     @Override
     public long getLastModified(HttpServletRequest req) {
 
-        RequestCache.openThreadCache();
-
-        long reqno = reqNumber.incrementAndGet();
-        ServletLogUtil.logServerAccessStart(req, ServletLogUtil.GATEWAY_ACCESS_LAST_MODIFIED_LOG_ID, "LastModified", Long.toString(reqno));
+        RequestCache.open(req);
+        ServletLogUtil.logServerAccessStart(req, ServletLogUtil.GATEWAY_ACCESS_LAST_MODIFIED_LOG_ID, "LastModified", RequestCache.getRequestId());
         try {
             if (ReqInfo.isServiceOnlyRequest(req))
                 return new Date().getTime();
@@ -207,7 +205,7 @@ public class DispatchServlet extends HttpServlet {
             }
         } finally {
             ServletLogUtil.logServerAccessEnd(request_status, ServletLogUtil.GATEWAY_ACCESS_LOG_ID);
-            RequestCache.closeThreadCache();
+            RequestCache.close();
         }
     }
 

--- a/src/opendap/gateway/DispatchServlet.java
+++ b/src/opendap/gateway/DispatchServlet.java
@@ -160,6 +160,8 @@ public class DispatchServlet extends HttpServlet {
         }
         finally {
             ServletLogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, ServletLogUtil.GATEWAY_ACCESS_LAST_MODIFIED_LOG_ID);
+            // We don't RequestCache.close() here so that the cache is
+            // available for the doGet() method which comes next.
         }
     }
 

--- a/src/opendap/hai/DispatchServlet.java
+++ b/src/opendap/hai/DispatchServlet.java
@@ -170,9 +170,8 @@ public class DispatchServlet extends opendap.coreServlet.DispatchServlet {
      *         since midnight January 1, 1970 GMT
      */
     protected long getLastModified(HttpServletRequest req) {
-        RequestCache.openThreadCache();
-        long reqno = reqNumber.incrementAndGet();
-        ServletLogUtil.logServerAccessStart(req, ServletLogUtil.ADMIN_ACCESS_LAST_MODIFIED_LOG_ID, "LastModified", Long.toString(reqno));
+        RequestCache.open(req);
+        ServletLogUtil.logServerAccessStart(req, ServletLogUtil.ADMIN_ACCESS_LAST_MODIFIED_LOG_ID, "LastModified", RequestCache.getRequestId());
         try {
             return new Date().getTime();
         }
@@ -246,7 +245,7 @@ public class DispatchServlet extends opendap.coreServlet.DispatchServlet {
             }
         } finally {
             ServletLogUtil.logServerAccessEnd(request_status, ServletLogUtil.ADMIN_ACCESS_LOG_ID);
-            RequestCache.closeThreadCache();
+            RequestCache.close();
         }
     }
 
@@ -294,7 +293,7 @@ public class DispatchServlet extends opendap.coreServlet.DispatchServlet {
             }
         } finally {
             ServletLogUtil.logServerAccessEnd(request_status, ServletLogUtil.ADMIN_ACCESS_LOG_ID);
-            RequestCache.closeThreadCache();
+            RequestCache.close();
         }
     }
 

--- a/src/opendap/hai/DispatchServlet.java
+++ b/src/opendap/hai/DispatchServlet.java
@@ -177,6 +177,8 @@ public class DispatchServlet extends opendap.coreServlet.DispatchServlet {
         }
         finally {
             ServletLogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, ServletLogUtil.ADMIN_ACCESS_LAST_MODIFIED_LOG_ID);
+            // We don't RequestCache.close() here so that the cache is
+            // available for the doGet() method which comes next.
         }
     }
 

--- a/src/opendap/ngap/NgapBesApi.java
+++ b/src/opendap/ngap/NgapBesApi.java
@@ -34,6 +34,7 @@ import opendap.bes.BadConfigurationException;
 import opendap.bes.BesApi;
 import opendap.coreServlet.OPeNDAPException;
 import opendap.coreServlet.ReqInfo;
+import opendap.coreServlet.RequestCache;
 import opendap.coreServlet.Util;
 import opendap.dap.User;
 import opendap.dap4.QueryParameters;
@@ -133,9 +134,7 @@ public class NgapBesApi extends BesApi implements Cloneable {
         log.debug("Building request for BES ngap_module request. remoteDataSourceUrl: "+ remoteDataSourceUrl);
         Element e, request = new Element("request", BES.BES_NS);
 
-        String reqID = "["+Thread.currentThread().getName()+":"+
-                Thread.currentThread().getId()+":ngap_request]";
-        request.setAttribute("reqID",reqID);
+        request.setAttribute(REQUEST_ID, RequestCache.getRequestId());
 
         request.addContent(setContextElement(EXPLICIT_CONTAINERS_CONTEXT,"no"));
 
@@ -250,10 +249,7 @@ public class NgapBesApi extends BesApi implements Cloneable {
 
         //String besDataSource = getBES(dataSource).trimPrefix(dataSource);
 
-        String reqID = Thread.currentThread().getName()+":"+ Thread.currentThread().getId();
-
-
-        request.setAttribute("reqID",reqID);
+        request.setAttribute(REQUEST_ID, RequestCache.getRequestId());
 
         request.addContent(setContextElement(EXPLICIT_CONTAINERS_CONTEXT,"no"));
 

--- a/src/opendap/threddsHandler/StaticCatalogDispatch.java
+++ b/src/opendap/threddsHandler/StaticCatalogDispatch.java
@@ -860,7 +860,7 @@ public class StaticCatalogDispatch implements DispatchHandler {
 
         Procedure timedProc = Timer.start();
 
-        RequestCache.openThreadCache();
+        RequestCache.open(req);
 
         String catalogKey = null;
         try {

--- a/src/opendap/threddsHandler/StaticCatalogDispatch.java
+++ b/src/opendap/threddsHandler/StaticCatalogDispatch.java
@@ -826,8 +826,8 @@ public class StaticCatalogDispatch implements DispatchHandler {
                                            boolean sendResponse)
             throws Exception {
 
-        String relativeUrl = ReqInfo.getLocalUrl(request);
-        String dataSource = relativeUrl; //_besApi.getBesDataSourceID(relativeUrl,false);
+        String dataSource = ReqInfo.getLocalUrl(request);
+        //_besApi.getBesDataSourceID(relativeUrl,false);
         //String requestSuffixRegex = ReqInfo.getRequestSuffix(request);
 
         boolean threddsRequest = false;

--- a/src/opendap/viewers/ViewersServlet.java
+++ b/src/opendap/viewers/ViewersServlet.java
@@ -384,9 +384,11 @@ public class ViewersServlet extends HttpServlet {
     @Override
     public void doGet(HttpServletRequest req, HttpServletResponse resp) {
 
-        RequestCache.openThreadCache();
-        ServletLogUtil.logServerAccessStart(req, ServletLogUtil.HYRAX_ACCESS_LOG_ID, "HTTP-GET", Integer.toString(REQ_NUMBER.incrementAndGet()));
-        LOG.debug(ServletUtil.showRequest(req, REQ_NUMBER.get()));
+        RequestCache.open(req);
+        String reqId = RequestCache.getRequestId();
+
+        ServletLogUtil.logServerAccessStart(req, ServletLogUtil.HYRAX_ACCESS_LOG_ID, "HTTP-GET", reqId);
+        LOG.debug(ServletUtil.showRequest(req, reqId));
 
         Request dapRequest = new Request(this,req);
         User user = new User(req);
@@ -490,7 +492,7 @@ public class ViewersServlet extends HttpServlet {
         }
         finally {
             ServletLogUtil.logServerAccessEnd(requestStatus, ServletLogUtil.HYRAX_ACCESS_LOG_ID);
-            RequestCache.closeThreadCache();
+            RequestCache.close();
             // this.destroy(); // I commented this out because: WTF? Why? - ndp 03/05/2019
         }
     }

--- a/src/opendap/w10n/W10nServlet.java
+++ b/src/opendap/w10n/W10nServlet.java
@@ -102,6 +102,8 @@ public class W10nServlet extends HttpServlet   {
         } finally {
             ServletLogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, ServletLogUtil.HYRAX_LAST_MODIFIED_ACCESS_LOG_ID);
             Timer.stop(timedProcedure);
+            // We don't RequestCache.close() here so that the cache is
+            // available for the doGet() method which comes next.
         }
         return lmt;
     }

--- a/src/opendap/w10n/W10nServlet.java
+++ b/src/opendap/w10n/W10nServlet.java
@@ -88,9 +88,8 @@ public class W10nServlet extends HttpServlet   {
      */
     @Override
     protected long getLastModified(HttpServletRequest req) {
-        RequestCache.openThreadCache();
-        long reqno = _reqNumber.incrementAndGet();
-        ServletLogUtil.logServerAccessStart(req, ServletLogUtil.HYRAX_LAST_MODIFIED_ACCESS_LOG_ID, "LastModified", Long.toString(reqno));
+        RequestCache.open(req);
+        ServletLogUtil.logServerAccessStart(req, ServletLogUtil.HYRAX_LAST_MODIFIED_ACCESS_LOG_ID, "LastModified", RequestCache.getRequestId());
         long lmt = new Date().getTime();
         Procedure timedProcedure = Timer.start();
         try {
@@ -119,12 +118,12 @@ public class W10nServlet extends HttpServlet   {
                     LicenseManager.sendLicenseExpiredPage(request,response);
                     return;
                 }
-                RequestCache.openThreadCache();
+                RequestCache.open(request);
 
-                int reqno = _reqNumber.incrementAndGet();
-                ServletLogUtil.logServerAccessStart(request, ServletLogUtil.HYRAX_ACCESS_LOG_ID, "HTTP-GET", Long.toString(reqno));
+                String reqId = RequestCache.getRequestId();
+                ServletLogUtil.logServerAccessStart(request, ServletLogUtil.HYRAX_ACCESS_LOG_ID, "HTTP-GET",reqId );
                 LOG.debug(Util.getMemoryReport());
-                LOG.debug(ServletUtil.showRequest(request, reqno));
+                LOG.debug(ServletUtil.showRequest(request, reqId));
                 //log.debug(AwsUtil.probeRequest(this, request));
                 if(redirectForServiceOnlyRequest(request,response))
                     return;
@@ -160,7 +159,7 @@ public class W10nServlet extends HttpServlet   {
         }
         finally {
             ServletLogUtil.logServerAccessEnd(request_status, ServletLogUtil.HYRAX_ACCESS_LOG_ID);
-            RequestCache.closeThreadCache();
+            RequestCache.close();
         }
 
         LOG.info(Timer.report());

--- a/src/opendap/wcs/v2_0/http/Servlet.java
+++ b/src/opendap/wcs/v2_0/http/Servlet.java
@@ -258,7 +258,7 @@ public class Servlet extends HttpServlet {
         }
         finally {
             ServletLogUtil.logServerAccessEnd(request_status, ServletLogUtil.WCS_ACCESS_LOG_ID);
-            RequestCache.closeThreadCache();
+            RequestCache.close();
 
         }
     }
@@ -306,7 +306,7 @@ public class Servlet extends HttpServlet {
         }
         finally {
             ServletLogUtil.logServerAccessEnd(request_status, ServletLogUtil.WCS_ACCESS_LOG_ID);
-            RequestCache.closeThreadCache();
+            RequestCache.close();
 
         }
     }
@@ -314,10 +314,9 @@ public class Servlet extends HttpServlet {
     @Override
     protected long getLastModified(HttpServletRequest req) {
 
-        RequestCache.openThreadCache();
+        RequestCache.open(req);
+        ServletLogUtil.logServerAccessStart(req, ServletLogUtil.WCS_LAST_MODIFIED_ACCESS_LOG_ID, "LastModified", RequestCache.getRequestId());
 
-        long reqno = reqNumber.incrementAndGet();
-        ServletLogUtil.logServerAccessStart(req, ServletLogUtil.WCS_LAST_MODIFIED_ACCESS_LOG_ID, "LastModified", Long.toString(reqno));
         try {
             return new Date().getTime();
         } finally {

--- a/src/opendap/wcs/v2_0/http/Servlet.java
+++ b/src/opendap/wcs/v2_0/http/Servlet.java
@@ -322,6 +322,8 @@ public class Servlet extends HttpServlet {
         } finally {
             ServletLogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, ServletLogUtil.WCS_LAST_MODIFIED_ACCESS_LOG_ID);
         }
+        // We don't RequestCache.close() here so that the cache is
+        // available for the doGet() method which comes next.
 
 
     }


### PR DESCRIPTION
Centralizes the determination of the request id (uuid?) into the ReqInfo utility classes.
Normalizes the use of the request id that is (now) held in the the RequestCache so that the value is propagated to the BES and to the OLFS's log4j content.