### PR TITLE
fix: no suitable method found for toString(Charset)

### DIFF
--- a/src/opendap/ppt/OPeNDAPClient.java
+++ b/src/opendap/ppt/OPeNDAPClient.java
@@ -725,7 +725,7 @@ public class OPeNDAPClient {
             throw new PPTException("Received error content from BES showStatus " +
                     "command! error_mdg: " + error);
         }
-        return response.toString(HyraxStringEncoding.getCharset());
+        return response.toString(HyraxStringEncoding.getCharset().toString());
     }
 
     public boolean isOk(){


### PR DESCRIPTION
I could not build OLFS using `ant server` on CentOS7 x86_64 with openjdk version "1.8.0_362."
This PR will fix the problem.


