### PR TITLE
Small changes to the request_log record format for NGAP mterics

### DIFF
--- a/resources/ngap/logback.xml
+++ b/resources/ngap/logback.xml
@@ -180,7 +180,7 @@
         <logGroup>hyrax_request_log</logGroup>
         <logStream>hyrax-%instanceId</logStream>
         <layout>
-            <pattern>{ "request_id": "%X{ID}", "user_id": "%X{userid}", "rangeBeginDateTime": "N/A", "rangeEndDateTime": "N/A", "collectionId": "%X{resourceID}", "bbox": "N/A", "parameters": { "service_name": "hyrax", "service_provider": "OPeNDAP", "service_id": "hyrax_prod" } }%n</pattern>
+            <pattern>{ "request_id": "%X{ID}", "user_id": "%X{userid}", "user_ip": "%X{host}", "rangeBeginDateTime": "", "rangeEndDateTime": "", "collectionId": "%X{resourceID}", "parameters": { "service_name": "hyrax", "service_provider": "OPeNDAP", "service_id": "hyrax_prod" } }%n</pattern>
         </layout>
     </appender>
 


### PR DESCRIPTION
> Amanda Monteavaro
> 1. For the request logs, one of the required fields is user_ip and I don't believe that field exists (at least not in SIT). Can you add that field as just an empty string?

ndp - Just to be sure: Would that be the IP address of the client that issued the request?
> 2.   Also for the request logs, we have rangeBeginDateTime and rangeEndDateTime set to be date types. The current value you have "N/A" is causing some conflicts with that and preventing data from being indexed. Can those be set to an empty string instead? If it's an empty string, we can remove the fields to prevent the indexing conflict

ndp - No problem.
> 3.   Also for request logs, we have the bbox field set to be an object which the current value you're sending "N/A" is causing conflicts as well, preventing indexing. The workaround for that would be if you can set that field to an empty object, or just omit it altogether

ndp - Let's just omit it, if that's OK with you.


> Amanda Monteavaro
> 1. Yes, that is supposed to be the IP of the client that issued the request - I mentioned the empty string assuming you weren't able to send that information, but if you have it, that would be great

> 3. Yup! I don't think anything will break by omitting it
> Do you have a timeline of when you'd be able to make those changes in all envs?

ndp - I think next week. I need to PR this change and then get it deployed to SIT so we can make sure it's cool. Even if we got to that today we (OPeNDAP) have a firm "No PROD deployments on Fridays. Just. No."
