### PR TITLE
Dropping units from response_size in logs

### DIFF
--- a/resources/ngap/logback.xml
+++ b/resources/ngap/logback.xml
@@ -39,7 +39,7 @@
         [%X{SOURCE}]      - The Source HTTP verb for the request, GET, POST, etc. 
         [%X{resourceID}]  - The local name/path/id of the requested object
         [%X{query}]       - The query string submitted by the client.
-        [%X{size}]        - Size of the response 
+        [%X{size}]        - Size of the response in bytes
         %n                - newline
 
         %t                - Outputs the name of the thread that generated the logging event.
@@ -200,7 +200,7 @@
         <logGroup>hyrax_response_log</logGroup>
         <logStream>hyrax-%instanceId</logStream>
         <layout>
-            <pattern>{ "request_id": "%X{ID}", "job_ids": ["N/A"], "http_response_code": %X{http_status}, "time_completed": "%d{yyyy-MM-dd'T'HH:mm:ssZ}", "total_time": %X{duration}, "output_size": "%X{size}" }%n</pattern>
+            <pattern>{ "request_id": "%X{ID}", "job_ids": ["N/A"], "http_response_code": %X{http_status}, "time_completed": "%d{yyyy-MM-dd'T'HH:mm:ssZ}", "total_time": %X{duration}, "output_size": %X{size} }%n</pattern>
         </layout>
     </appender>
 

--- a/src/opendap/logging/ServletLogUtil.java
+++ b/src/opendap/logging/ServletLogUtil.java
@@ -472,7 +472,7 @@ public class ServletLogUtil {
     public static void setResponseSize(long size){
         // Only set the size if it's not equal to the missing value (-1)
         if(size>=0) {
-            MDC.put(RESPONSE_SIZE_KEY, Long.toString(size) + " bytes");
+            MDC.put(RESPONSE_SIZE_KEY, Long.toString(size));
         }
     }
 


### PR DESCRIPTION
Drop the units from the value of response size in the logs.