### PR TITLE
First pass at sending a value of -1 to indicate unknown output_size

### DIFF
--- a/src/opendap/bes/BESSiteMapService.java
+++ b/src/opendap/bes/BESSiteMapService.java
@@ -160,7 +160,7 @@ public class BESSiteMapService extends HttpServlet {
 
 
         int request_status = HttpServletResponse.SC_OK;
-        int response_size = -1;
+        int response_size = ServletLogUtil.MISSING_SIZE_VALUE;
         try {
             Procedure timedProcedure = Timer.start();
             RequestCache.open(request);

--- a/src/opendap/coreServlet/DispatchServlet.java
+++ b/src/opendap/coreServlet/DispatchServlet.java
@@ -48,7 +48,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.StringTokenizer;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -224,26 +223,26 @@ public class DispatchServlet extends HttpServlet {
      *     to requests for a dataset resource URL, meaning that the response
      *     will be either source data file or an HTTP 403 Forbidden error, as
      *     defined by the state of the AllowDirectDataSourceAccess feature.
-     *
+     * <br/>
      *     If UseDAP2ResourceUrlResponse is not enabled (not present in the
      *     configuration, or commented out) the server will default to returning
      *     the DAP4 Dataset Services Response (DSR) when a dataset resource URL
      *     is requested.
-     *
+     * <br/>
      *     See Dap4 specification for more:
      *     https://docs.opendap.org/index.php?title=OPULS_Development#DAP4_Specification
      * -->
      * <UseDAP2ResourceUrlResponse />
-     *
+     * <br/>
      * <!--
      *     DataRequestForm
-     *
+     * <br/>
      *     Defines the DAP data model version for the DAta Request Form linked to
      *     from the "blue-bar" catalog.html pages generated from  either the
      *     DDX (for DAP2) or the DMR (for DAP4).
-     * -->
+     * <br/>
      * <DataRequestForm type="dap4" />
-     *
+     * <br/>
      *
      * </Handler>
      * <Handler className="opendap.bes.DirectoryDispatchHandler" />

--- a/src/opendap/coreServlet/DispatchServlet.java
+++ b/src/opendap/coreServlet/DispatchServlet.java
@@ -586,7 +586,7 @@ public class DispatchServlet extends HttpServlet {
     protected long getLastModified(HttpServletRequest req) {
 
         RequestCache.open(req);
-        ServletLogUtil.logServerAccessStart(req, ServletLogUtil.HYRAX_LAST_MODIFIED_ACCESS_LOG_ID, "LastModified", RequestCache.getRequestId());
+        //ServletLogUtil.logServerAccessStart(req, ServletLogUtil.HYRAX_LAST_MODIFIED_ACCESS_LOG_ID, "LastModified", RequestCache.getRequestId());
 
         long lmt = new Date().getTime();
 
@@ -607,7 +607,7 @@ public class DispatchServlet extends HttpServlet {
             log.error("Caught: {}  Message: {} ", e.getClass().getName(), e.getMessage());
             lmt = new Date().getTime();
         } finally {
-            ServletLogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, ServletLogUtil.HYRAX_LAST_MODIFIED_ACCESS_LOG_ID);
+            //ServletLogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, ServletLogUtil.HYRAX_LAST_MODIFIED_ACCESS_LOG_ID);
             Timer.stop(timedProcedure);
             // We don't RequestCache.close() here so that the cache is
             // available for the doGet() method which comes next.

--- a/src/opendap/coreServlet/DispatchServlet.java
+++ b/src/opendap/coreServlet/DispatchServlet.java
@@ -586,7 +586,7 @@ public class DispatchServlet extends HttpServlet {
     protected long getLastModified(HttpServletRequest req) {
 
         RequestCache.open(req);
-        //ServletLogUtil.logServerAccessStart(req, ServletLogUtil.HYRAX_LAST_MODIFIED_ACCESS_LOG_ID, "LastModified", RequestCache.getRequestId());
+        ServletLogUtil.logServerAccessStart(req, ServletLogUtil.HYRAX_LAST_MODIFIED_ACCESS_LOG_ID, "LastModified", RequestCache.getRequestId());
 
         long lmt = new Date().getTime();
 
@@ -607,7 +607,7 @@ public class DispatchServlet extends HttpServlet {
             log.error("Caught: {}  Message: {} ", e.getClass().getName(), e.getMessage());
             lmt = new Date().getTime();
         } finally {
-            //ServletLogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, ServletLogUtil.HYRAX_LAST_MODIFIED_ACCESS_LOG_ID);
+            ServletLogUtil.logServerAccessEnd(HttpServletResponse.SC_OK, ServletLogUtil.HYRAX_LAST_MODIFIED_ACCESS_LOG_ID);
             Timer.stop(timedProcedure);
             // We don't RequestCache.close() here so that the cache is
             // available for the doGet() method which comes next.

--- a/src/opendap/coreServlet/DispatchServlet.java
+++ b/src/opendap/coreServlet/DispatchServlet.java
@@ -324,20 +324,18 @@ public class DispatchServlet extends HttpServlet {
     /**
      * Temporary implementation HEAD denial response. Because in most cases
      * the server has to do a lot of work to get a Content-Length value.
-     *
+     * <br />
      * The default implementation of doHead() appears to replace the
      * ServletOutputStream in the response with a a stream that counts bytes
      * but does not transmot them. Maybe this makes sense for an file service,
      * but not here. We could refine this by adding DispatchHandler.doHead()
      * and having each handler do something that makes sense.
      *
-     * @param request
-     * @param response
-     * @throws ServletException
-     * @throws IOException
+     * @param request The request to be handled
+     * @param response The response to which the outcome will be transmitted
      */
     @Override
-    public void doHead(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+    public void doHead(HttpServletRequest request, HttpServletResponse response) {
 
         String relativeUrl = ReqInfo.getLocalUrl(request);
 

--- a/src/opendap/coreServlet/DispatchServlet.java
+++ b/src/opendap/coreServlet/DispatchServlet.java
@@ -35,19 +35,13 @@ import opendap.logging.Procedure;
 import opendap.logging.Timer;
 import org.jdom.Document;
 import org.jdom.Element;
-import org.jdom.JDOMException;
-import org.jdom.input.SAXBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -86,7 +80,6 @@ public class DispatchServlet extends HttpServlet {
      *
      * @serial
      */
-    private static final AtomicInteger reqNumber = new AtomicInteger(0);
     private static final AtomicBoolean IS_INITIALIZED = new AtomicBoolean(false);
     private static final ReentrantLock INIT_LOCK = new ReentrantLock();
 
@@ -104,7 +97,7 @@ public class DispatchServlet extends HttpServlet {
      * servlet InitParameters. The Debug object can be referenced (with
      * impunity) from any of the dods code...
      *
-     * @throws javax.servlet.ServletException
+     * @throws javax.servlet.ServletException When the bad things happen.
      */
     public void init() throws ServletException {
         INIT_LOCK.lock();
@@ -261,7 +254,7 @@ public class DispatchServlet extends HttpServlet {
      * @param httpPostHandlers The list of POST handlers for the OLFS to use.
      * @param enablePost If the value is TRU then the POST handling will be enabled.
      * @param config The configuration Element to use when configuring the service.
-     * @throws Exception
+     * @throws Exception When the bad things happen
      */
     private void loadHyraxServiceHandlers(
             List<DispatchHandler> httpGetHandlers,

--- a/src/opendap/coreServlet/DocServlet.java
+++ b/src/opendap/coreServlet/DocServlet.java
@@ -120,7 +120,6 @@ public class DocServlet extends HttpServlet {
             String servletName = "/" + this.getServletName();
 
             String reqId = RequestCache.getRequestId();
-
             ServletLogUtil.logServerAccessStart(request, ServletLogUtil.DOCS_ACCESS_LOG_ID, "HTTP-GET", reqId);
 
             if (!redirect(request, response)) {

--- a/src/opendap/coreServlet/DocServlet.java
+++ b/src/opendap/coreServlet/DocServlet.java
@@ -112,13 +112,16 @@ public class DocServlet extends HttpServlet {
     public void doGet(HttpServletRequest request, HttpServletResponse response) {
 
         int status = HttpServletResponse.SC_OK;
+        RequestCache.open(request);
 
-        int response_size = 0;
+        int response_size = ServletLogUtil.MISSING_SIZE_VALUE;
         try {
             String contextPath = ServletUtil.getContextPath(this);
             String servletName = "/" + this.getServletName();
 
-            ServletLogUtil.logServerAccessStart(request, ServletLogUtil.DOCS_ACCESS_LOG_ID, "HTTP-GET", Integer.toString(reqNumber.incrementAndGet()));
+            String reqId = RequestCache.getRequestId();
+
+            ServletLogUtil.logServerAccessStart(request, ServletLogUtil.DOCS_ACCESS_LOG_ID, "HTTP-GET", reqId);
 
             if (!redirect(request, response)) {
 
@@ -214,6 +217,8 @@ public class DocServlet extends HttpServlet {
             }
         } finally {
             ServletLogUtil.logServerAccessEnd(status, response_size, ServletLogUtil.DOCS_ACCESS_LOG_ID);
+            RequestCache.close();
+            log.info("Response completed.\n");
         }
     }
 

--- a/src/opendap/logging/ServletLogUtil.java
+++ b/src/opendap/logging/ServletLogUtil.java
@@ -108,6 +108,8 @@ public class ServletLogUtil {
     private static final AtomicBoolean useCombinedLog = new AtomicBoolean(false);
     public static final AtomicBoolean useDualCloudWatchLogs = new AtomicBoolean(false);
 
+    public static final int MISSING_SIZE_VALUE = -1;
+
 
     private static Logger log;
     static{
@@ -471,9 +473,9 @@ public class ServletLogUtil {
      */
     public static void setResponseSize(long size){
         // Only set the size if it's not equal to the missing value (-1)
-        if(size>=0) {
+        String mdc_size = MDC.get(RESPONSE_SIZE_KEY);
+        if(mdc_size==null || mdc_size.isEmpty())
             MDC.put(RESPONSE_SIZE_KEY, Long.toString(size));
-        }
     }
 
 
@@ -484,9 +486,8 @@ public class ServletLogUtil {
      * @param logName the name of the Logger to which to write stuff.
      */
     public static void logServerAccessEnd(int httpStatus, String logName) {
-        logServerAccessEnd(httpStatus, -1, logName);
+        logServerAccessEnd(httpStatus, MISSING_SIZE_VALUE, logName);
     }
-
 
     /**
      * Write log entry to named log.

--- a/src/opendap/logging/ServletLogUtil.java
+++ b/src/opendap/logging/ServletLogUtil.java
@@ -564,10 +564,12 @@ public class ServletLogUtil {
 
     public static void useCombinedLog(boolean value) {
         useCombinedLog.set(value);
+        log.info("Combined OLFS/BES Log Is {}", value ? "ENABLED." : "DISABLED");
     }
 
     public static void useDualCloudWatchLogs(boolean value) {
         useDualCloudWatchLogs.set(value);
+        log.info("CloudWatch Logs Are {}", value ? "ENABLED." : "DISABLED");
     }
 
     public static void mdcPut(String key, String value){

--- a/src/opendap/logging/ServletLogUtil.java
+++ b/src/opendap/logging/ServletLogUtil.java
@@ -469,11 +469,13 @@ public class ServletLogUtil {
 
     /**
      * Used in various places in the server to add the response size to the log.
-     * @param size The size, in bytes, of the response. Values less than 0 will be ignored.
+     * Will set the response if it has not already been set or if it's value is empty.
+     * @param size The size, in bytes, of the response. A value of -1 indicates that the size is unknown
      */
     public static void setResponseSize(long size){
-        // Only set the size if it's not equal to the missing value (-1)
+
         String mdc_size = MDC.get(RESPONSE_SIZE_KEY);
+        // Was it set? Is it empty??
         if(mdc_size==null || mdc_size.isEmpty())
             MDC.put(RESPONSE_SIZE_KEY, Long.toString(size));
     }

--- a/src/opendap/logging/ServletLogUtil.java
+++ b/src/opendap/logging/ServletLogUtil.java
@@ -75,9 +75,6 @@ public class ServletLogUtil {
     public static final String ADMIN_ACCESS_LOG_ID = "HyraxAdminAccess";
     public static final String ADMIN_ACCESS_LAST_MODIFIED_LOG_ID = "HyraxAdminLastModifiedAccess";
 
-    public static final String S3_SERVICE_ACCESS_LOG_ID = "S3ServiceAccess";
-    public static final String S3_SERVICE_LAST_MODIFIED_LOG_ID = "S3ServiceLastModifiedAccess";
-
     public static final String WCS_ACCESS_LOG_ID = "WCSAccess";
     public static final String WCS_LAST_MODIFIED_ACCESS_LOG_ID = "WCSLastModifiedAccess";
 
@@ -111,7 +108,7 @@ public class ServletLogUtil {
     public static final int MISSING_SIZE_VALUE = -1;
 
 
-    private static Logger log;
+    private static final Logger log;
     static{
         System.out.println("+++LogUtil.static - Instantiating Logger ...");
         try {
@@ -285,7 +282,7 @@ public class ServletLogUtil {
             log.error("Caught {} Message: {}",je.getClass().getName(),je.getMessage());
             StringWriter sw = new StringWriter();
             je.printStackTrace(new PrintWriter(sw));
-            log.error("Stack trace: \n{}",sw.toString());
+            log.error("Stack trace: \n{}",sw);
         }
     }
 
@@ -401,13 +398,12 @@ public class ServletLogUtil {
         MDC.put(QUERY_STRING_KEY, query);
 
         if(log.isInfoEnabled()) {
-            StringBuilder startMsg = new StringBuilder();
-            startMsg.append("REQUEST START - ");
-            startMsg.append("RemoteHost: '").append(LogUtil.scrubEntry(req.getRemoteHost())).append("' ");
-            startMsg.append("RequestedResource: '").append(resourceID).append("' ");
-            startMsg.append("QueryString: '").append(query).append("' ");
-            startMsg.append("AccessLog: ").append(logName);
-            log.info(startMsg.toString());
+            String startMsg = "REQUEST START - " +
+                    "RemoteHost: '" + LogUtil.scrubEntry(req.getRemoteHost()) + "' " +
+                    "RequestedResource: '" + resourceID + "' " +
+                    "QueryString: '" + query + "' " +
+                    "AccessLog: " + logName;
+            log.info(startMsg);
         }
         if(logName.equals(HYRAX_ACCESS_LOG_ID) && useDualCloudWatchLogs.get()){
             Logger cwRequestLog = org.slf4j.LoggerFactory.getLogger(CLOUDWATCH_REQUEST_LOG);
@@ -504,7 +500,7 @@ public class ServletLogUtil {
         long  duration = -1;
         String sTime = MDC.get("startTime");
         if(sTime!=null) {
-            long startTime = Long.valueOf(sTime);
+            long startTime = Long.parseLong(sTime);
             duration = endTime - startTime;
         }
         MDC.put(DURATION_KEY, (duration>=0)?Long.toString(duration):"unknown" +" ms");
@@ -572,14 +568,6 @@ public class ServletLogUtil {
     public static void useDualCloudWatchLogs(boolean value) {
         useDualCloudWatchLogs.set(value);
         log.info("CloudWatch Logs Are {}", value ? "ENABLED." : "DISABLED");
-    }
-
-    public static void mdcPut(String key, String value){
-        MDC.put(key, value);
-    }
-
-    public static String mdcGet(String key){
-        return MDC.get(key);
     }
 
 }

--- a/src/opendap/ngap/NgapDispatchHandler.java
+++ b/src/opendap/ngap/NgapDispatchHandler.java
@@ -47,7 +47,7 @@ import java.util.regex.Pattern;
  * User: dan
  * Date: 2/13/20
  * Time: 1:35 PM
- * Cloned from: opendap.gateway
+ * Cloned from: opendap/gateway
  * To change this template use File | Settings | File Templates.
  */
 public class NgapDispatchHandler extends BesDapDispatcher {
@@ -70,13 +70,11 @@ public class NgapDispatchHandler extends BesDapDispatcher {
         reqCounter = new AtomicLong(0);
     }
 
-    private Logger log;
+    private final Logger log;
     private boolean _initialized;
     private String _prefix;
     private NgapBesApi _besApi;
     //private NGAPForm _ngapForm;
-
-    private static final String d_landingPage="/docs/ngap/ngap.html";
 
     public NgapDispatchHandler() {
         super();
@@ -113,7 +111,7 @@ public class NgapDispatchHandler extends BesDapDispatcher {
             throws Exception {
 
         String relativeURL = ReqInfo.getLocalUrl(request);
-        log.debug("relativeURL:    "+relativeURL);
+        log.debug("relativeURL: {}",relativeURL);
 
         while(relativeURL.startsWith(THE_SLASH) && relativeURL.length()>1)
             relativeURL = relativeURL.substring(1);
@@ -127,7 +125,7 @@ public class NgapDispatchHandler extends BesDapDispatcher {
 
                 if(itsJustThePrefixWithoutTheSlash ){
                     response.sendRedirect(_prefix);
-                    log.debug("Sent redirect to service prefix: "+_prefix);
+                    log.debug("Sent redirect to service prefix: {}",_prefix);
                     return true;
                 }
 
@@ -185,7 +183,7 @@ public class NgapDispatchHandler extends BesDapDispatcher {
         if (_prefix.startsWith("/"))
             _prefix = _prefix.substring(1);
 
-        log.info("Using prefix=" + _prefix);
+        log.info("Using service prefix: {}", _prefix);
 
     }
 


### PR DESCRIPTION
This PR address the problem in our CloudWatch logs where the response size is not known. If that happens then we send a -1 for response size (approved scheme by metrics folks)

Additionally it fixes a number of the missing output_size pathways.