### PR TITLE
Query2request log

### DIFF
--- a/resources/ngap/logback.xml
+++ b/resources/ngap/logback.xml
@@ -171,6 +171,7 @@
         "rangeBeginDateTime",
         "rangeEndDateTime",
         "collectionId",
+        "query_string", # Added by us because..."
         "bbox",
         "parameters"
     ]
@@ -180,7 +181,7 @@
         <logGroup>hyrax_request_log</logGroup>
         <logStream>hyrax-%instanceId</logStream>
         <layout>
-            <pattern>{ "request_id": "%X{ID}", "user_id": "%X{userid}", "user_ip": "%X{host}", "rangeBeginDateTime": "", "rangeEndDateTime": "", "collectionId": "%X{resourceID}", "parameters": { "service_name": "hyrax", "service_provider": "OPeNDAP", "service_id": "hyrax_prod" } }%n</pattern>
+            <pattern>{ "request_id": "%X{ID}", "user_id": "%X{userid}", "user_ip": "%X{host}", "rangeBeginDateTime": "", "rangeEndDateTime": "", "collectionId": "%X{resourceID}", "query_string": "%X{query}", "parameters": { "service_name": "hyrax", "service_provider": "OPeNDAP", "service_id": "hyrax_prod" } }%n</pattern>
         </layout>
     </appender>
 

--- a/src/opendap/logging/ServletLogUtil.java
+++ b/src/opendap/logging/ServletLogUtil.java
@@ -394,7 +394,7 @@ public class ServletLogUtil {
         MDC.put(RESOURCE_ID_KEY,resourceID);
 
         String query = Scrub.simpleQueryString(req.getQueryString());
-        query = (query == null) ? "" : query;
+        query = (query == null) ? "-" : query;
         MDC.put(QUERY_STRING_KEY, query);
 
         if(log.isInfoEnabled()) {

--- a/src/opendap/logging/ServletLogUtil.java
+++ b/src/opendap/logging/ServletLogUtil.java
@@ -394,7 +394,7 @@ public class ServletLogUtil {
         MDC.put(RESOURCE_ID_KEY,resourceID);
 
         String query = Scrub.simpleQueryString(req.getQueryString());
-        query = (query == null) ? "-" : query;
+        query = (query == null || query.isEmpty()) ? "-" : query;
         MDC.put(QUERY_STRING_KEY, query);
 
         if(log.isInfoEnabled()) {


### PR DESCRIPTION
Adds the query string to our CloudWatch request_log output:

```
{
  "request_id": "http-nio-8080-exec-9_26_b10c18a0-ac3b-43d4-849a-a6c00ccbc5cd",
  "user_id": "-",
  "user_ip": "0:0:0:0:0:0:0:1",
  "rangeBeginDateTime": "",
  "rangeEndDateTime": "",
  "collectionId": "/opendap/hyrax/data/nc/fnoc1.nc.dmr.html",
  "query_string": "dap4.ce=u#v",
  "parameters": {
    "service_name": "hyrax",
    "service_provider": "OPeNDAP",
    "service_id": "hyrax_prod"
  }
}
```