### PR TITLE
protect our logs from duplicate request ids

### DIFF
--- a/src/opendap/auth/IdFilter.java
+++ b/src/opendap/auth/IdFilter.java
@@ -27,10 +27,7 @@
 package opendap.auth;
 
 import opendap.PathBuilder;
-import opendap.coreServlet.OPeNDAPException;
-import opendap.coreServlet.ReqInfo;
-import opendap.coreServlet.RequestCache;
-import opendap.coreServlet.ServletUtil;
+import opendap.coreServlet.*;
 import opendap.http.error.Forbidden;
 import opendap.logging.ServletLogUtil;
 import org.jdom.Element;
@@ -178,7 +175,7 @@ public class IdFilter implements Filter {
 
             HttpServletRequest request = (HttpServletRequest) sreq;
             RequestCache.open(request);
-            String requestId = RequestCache.getRequestId();
+            RequestId requestId = RequestCache.getRequestId();
 
             HttpServletRequest hsReq = request;
 

--- a/src/opendap/bes/BESSiteMapService.java
+++ b/src/opendap/bes/BESSiteMapService.java
@@ -164,7 +164,7 @@ public class BESSiteMapService extends HttpServlet {
         try {
             Procedure timedProcedure = Timer.start();
             RequestCache.open(request);
-            String reqId = RequestCache.getRequestId();
+            RequestId reqId = RequestCache.getRequestId();
             try {
 
                 ServletLogUtil.logServerAccessStart(request, ServletLogUtil.SITEMAP_ACCESS_LOG_ID, "HTTP-GET", reqId);

--- a/src/opendap/bes/BesApi.java
+++ b/src/opendap/bes/BesApi.java
@@ -30,10 +30,7 @@ import opendap.PathBuilder;
 import opendap.auth.EarthDataLoginAccessToken;
 import opendap.auth.UserProfile;
 import opendap.bes.caching.BesNodeCache;
-import opendap.coreServlet.ByteArrayOutputStreamTransmitCoordinator;
-import opendap.coreServlet.RequestCache;
-import opendap.coreServlet.ResourceInfo;
-import opendap.coreServlet.TransmitCoordinator;
+import opendap.coreServlet.*;
 import opendap.dap.User;
 import opendap.dap4.QueryParameters;
 import opendap.logging.ServletLogUtil;
@@ -108,6 +105,7 @@ public class BesApi implements Cloneable {
     public static final String DEFAULT_SUPPORT_EMAIL_ADDRESS   = "support@opendap.org";
 
     public static final String REQUEST_ID_KEY = "reqID";
+    public static final String REQUEST_UUID_KEY = "reqUUID";
     public static final String BES_CLIENT_ID_KEY = "clientId";
     public static final String BES_CLIENT_CMD_COUNT_KEY = "clientCmdCount";
 
@@ -2330,7 +2328,9 @@ public class BesApi implements Cloneable {
 
 
         Element e, request = new Element("request", BES_NS);
-        request.setAttribute(REQUEST_ID_KEY, RequestCache.getRequestId());
+        RequestId rid = RequestCache.getRequestId();
+        request.setAttribute(REQUEST_ID_KEY, rid.id());
+        request.setAttribute(REQUEST_UUID_KEY, rid.uuid().toString());
 
         request.addContent(setContextElement(XDAP_ACCEPT_CONTEXT, DEFAULT_XDAP_ACCEPT));
 
@@ -2422,7 +2422,9 @@ public class BesApi implements Cloneable {
 
         Element e, request = new Element("request", BES_NS);
 
-        request.setAttribute(REQUEST_ID_KEY, RequestCache.getRequestId());
+        RequestId rid = RequestCache.getRequestId();
+        request.setAttribute(REQUEST_ID_KEY, rid.id());
+        request.setAttribute(REQUEST_UUID_KEY, rid.uuid().toString());
 
         //----------------------------------------------------------------------
         // Added this bit for the cloudy dap experiment - ndp 1/19/17
@@ -2489,7 +2491,9 @@ public class BesApi implements Cloneable {
     public  Document getSiteMapRequestDocument(String sitePrefix) {
 
         Element request = new Element("request", BES_NS);
-        request.setAttribute(REQUEST_ID_KEY, RequestCache.getRequestId());
+        RequestId rid = RequestCache.getRequestId();
+        request.setAttribute(REQUEST_ID_KEY, rid.id());
+        request.setAttribute(REQUEST_UUID_KEY, rid.uuid().toString());
 
         request.addContent(setContextElement(EXPLICIT_CONTAINERS_CONTEXT,"no"));
         request.addContent(setContextElement(ERRORS_CONTEXT,XML_ERRORS));
@@ -2538,7 +2542,9 @@ public class BesApi implements Cloneable {
 
 
         Element request = new Element("request", BES_NS);
-        request.setAttribute(REQUEST_ID_KEY, RequestCache.getRequestId());
+        RequestId rid = RequestCache.getRequestId();
+        request.setAttribute(REQUEST_ID_KEY, rid.id());
+        request.setAttribute(REQUEST_UUID_KEY, rid.uuid().toString());
 
         request.addContent(setContextElement(EXPLICIT_CONTAINERS_CONTEXT,"no"));
         request.addContent(setContextElement(ERRORS_CONTEXT,XML_ERRORS));
@@ -2589,7 +2595,10 @@ public class BesApi implements Cloneable {
 
 
         Element e, request = new Element("request", BES_NS);
-        request.setAttribute(REQUEST_ID_KEY, RequestCache.getRequestId());
+        RequestId rid = RequestCache.getRequestId();
+        request.setAttribute(REQUEST_ID_KEY, rid.id());
+        request.setAttribute(REQUEST_UUID_KEY, rid.uuid().toString());
+
         request.addContent(setContextElement(ERRORS_CONTEXT,XML_ERRORS));
 
         e = new Element(type,BES_NS);
@@ -2853,7 +2862,10 @@ public class BesApi implements Cloneable {
     public static Document getShowBesKeyRequestDocument(String besKey) {
 
         Element request = new Element("request", BES_NS);
-        request.setAttribute(REQUEST_ID_KEY, RequestCache.getRequestId());
+        RequestId rid = RequestCache.getRequestId();
+        request.setAttribute(REQUEST_ID_KEY, rid.id());
+        request.setAttribute(REQUEST_UUID_KEY, rid.uuid().toString());
+
         request.addContent(setContextElement(EXPLICIT_CONTAINERS_CONTEXT,"no"));
         request.addContent(setContextElement(ERRORS_CONTEXT,XML_ERRORS));
         request.addContent(showBesKeyRequestElement(besKey));

--- a/src/opendap/coreServlet/DispatchServlet.java
+++ b/src/opendap/coreServlet/DispatchServlet.java
@@ -400,7 +400,7 @@ public class DispatchServlet extends HttpServlet {
             Procedure timedProcedure = Timer.start();
 
             RequestCache.open(request);
-            String reqId = RequestCache.getRequestId();
+            RequestId reqId = RequestCache.getRequestId();
 
             try {
 
@@ -497,7 +497,7 @@ public class DispatchServlet extends HttpServlet {
             try {
 
                 RequestCache.open(request);
-                String reqId = RequestCache.getRequestId();
+                RequestId reqId = RequestCache.getRequestId();
 
                 ServletLogUtil.logServerAccessStart(request, ServletLogUtil.HYRAX_ACCESS_LOG_ID, "HTTP-POST", reqId);
 

--- a/src/opendap/coreServlet/DocServlet.java
+++ b/src/opendap/coreServlet/DocServlet.java
@@ -119,7 +119,7 @@ public class DocServlet extends HttpServlet {
             String contextPath = ServletUtil.getContextPath(this);
             String servletName = "/" + this.getServletName();
 
-            String reqId = RequestCache.getRequestId();
+            RequestId reqId = RequestCache.getRequestId();
             ServletLogUtil.logServerAccessStart(request, ServletLogUtil.DOCS_ACCESS_LOG_ID, "HTTP-GET", reqId);
 
             if (!redirect(request, response)) {

--- a/src/opendap/coreServlet/ReqInfo.java
+++ b/src/opendap/coreServlet/ReqInfo.java
@@ -51,38 +51,8 @@ import java.util.regex.Pattern;
 import static opendap.http.Util.PROTOCOL_TERMINATION;
 
 
-/**
- * Provides utility methods that perform "analysis" of the user request and return important componet strings
- * for the OPeNDAP servlet.
- *
- * The dataSourceName is the local URL path of the request, minus any requestSuffixRegex detected. So, if the request is
- * for a dataset (an atom) then the dataSourceName is the local path and the name of the dataset minus the
- * requestSuffixRegex. If the request is for a collection, then the dataSourceName is the complete local path.
- * <p><b>Examples:</b>
- * <ul><li>If the complete URL were: http://opendap.org:8080/opendap/nc/fnoc1.nc.dds?lat,lon,time&lat>72.0<br/>
- * Then the:</li>
- * <ul>
- * <li> RequestURL = http://opendap.org:8080/opendap/nc/fnoc1.nc </li>
- * <li> CollectionName = /opendap/nc/ </li>
- * <li> DataSetName = fnoc1.nc </li>
- * <li> DataSourceName = /opendap/nc/fnoc1.nc </li>
- * <li> RequestSuffix = dds </li>
- * <li> ConstraintExpression = lat,lon,time&lat>72.0 </li>
- * </ul>
- *
- * <li>If the complete URL were: http://opendap.org:8080/opendap/nc/<br/>
- * Then the:</li>
- * <ul>
- * <li> RequestURL = http://opendap.org:8080/opendap/nc/ </li>
- * <li> CollectionName = /opendap/nc/ </li>
- * <li> DataSetName = null </li>
- * <li> DataSourceName = /opendap/nc/ </li>
- * <li> RequestSuffix = "" </li>
- * <li> ConstraintExpression = "" </li>
- * </ul>
- * </ul>
- * @author Nathan Potter
- */
+;
+
 
 public class ReqInfo {
 
@@ -927,38 +897,37 @@ public class ReqInfo {
     /**
      * A request header key/name to check for a request id.
      */
-    public static final String REQUEST_UUID_KEY="a-api-request-uuid";
+    public static final String REQUEST_ID_HEADER_KEY ="a-api-request-uuid";
 
-    /**
-     * Returns the unique id of this request. If upstream service chain
-     * components have provided one in the request headers it will be sanitized
-     * and returned. Otherwise, a new request ID will be minted and returned.
-     * @param req
-     * @return
-     */
-    public static String getRequestId(HttpServletRequest req){
-        String reqID;
+    // public static String getRequestId(HttpServletRequest req){ return "";}
 
-        reqID = req.getHeader(REQUEST_UUID_KEY);
-        if(reqID != null) {
+        /**
+         * Returns the unique id of this request. If upstream service chain
+         * components have provided one in the request headers it will be sanitized
+         * and returned. Otherwise, a new request ID will be minted and returned.
+         * @param req
+         * @return
+         */
+    public static RequestId getRequestId(HttpServletRequest req){
+        // Contains a fresh uuid
+        RequestId reqId = new RequestId();
+
+        // Add additional req.getHeader() calls for different keys as needed.
+        String request_id_header = req.getHeader(REQUEST_ID_HEADER_KEY);
+        if(request_id_header != null) {
             // TODO Determine the allowed characters and associated format
             //  for the REQUEST_UUID_KEY and use that to implement a closely
             //  tailored Scrub method to use for sanitizing this input
-            reqID = Scrub.simpleString(reqID);
-            return reqID;
+            reqId.id(Scrub.simpleString(request_id_header));
         }
-        // Add additional req.getHeader() calls for different keys as needed.
-
-
-        // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-        // DEFAULT
-        // No service chain request ID appears in the expected request headers
-        // so make a homegrown request_id and send it on.
-        UUID uuid = UUID.randomUUID();
-        reqID = Thread.currentThread().getName() +
-                "_" + Thread.currentThread().getId() +
-                "_" + uuid;
-        return reqID;
+        else {
+            // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+            // DEFAULT
+            // No service chain request ID appears in the expected request headers
+            // so make a homegrown request_id and send it on.
+            reqId.id(Thread.currentThread().getName() + "_" + Thread.currentThread().getId());
+        }
+        return reqId;
     }
 
 }

--- a/src/opendap/coreServlet/RequestCache.java
+++ b/src/opendap/coreServlet/RequestCache.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import javax.servlet.http.HttpServletRequest;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -90,7 +91,7 @@ public class RequestCache {
             HashMap<String,CachedObj> tcache = cache.get(thisThread);
             CachedObj idObj = tcache.get(REQUEST_ID_KEY);
             if(idObj==null || !(idObj.getObj() instanceof String) ){
-                String reqId = ReqInfo.getRequestId(request);
+                RequestId reqId = ReqInfo.getRequestId(request);
                 put(REQUEST_ID_KEY,reqId);
                 log.info("Cached new request id: {}", reqId);
             }
@@ -102,7 +103,7 @@ public class RequestCache {
             HashMap<String, CachedObj> hm = new HashMap<>();
             cache.put(thisThread, hm);
             log.info("Created request cache for thread: {}", thisThread.getName());
-            String reqId = ReqInfo.getRequestId(request);
+            RequestId reqId = ReqInfo.getRequestId(request);
             put(REQUEST_ID_KEY,reqId);
             log.info("Cached new request id: {}", reqId);
         }
@@ -164,12 +165,12 @@ public class RequestCache {
      *
      * @return The request id being serviced by the current thread.
      */
-    public static String getRequestId(){
+    public static RequestId getRequestId(){
         Object id = get(REQUEST_ID_KEY);
         if(id != null){
-            return (String)id;
+            return (RequestId)id;
         }
-        return "THIS_GETS_FIXED_LATER";
+        return new RequestId("ERROR(NOT FATAL): No request id was located in the RequestCache.");
     }
 
 }

--- a/src/opendap/coreServlet/RequestId.java
+++ b/src/opendap/coreServlet/RequestId.java
@@ -1,0 +1,57 @@
+package opendap.coreServlet;
+
+import java.util.UUID;
+
+/**
+ * Provides utility methods that perform "analysis" of the user request and return important componet strings
+ * for the OPeNDAP servlet.
+ * <p>
+ * The dataSourceName is the local URL path of the request, minus any requestSuffixRegex detected. So, if the request is
+ * for a dataset (an atom) then the dataSourceName is the local path and the name of the dataset minus the
+ * requestSuffixRegex. If the request is for a collection, then the dataSourceName is the complete local path.
+ * <p><b>Examples:</b>
+ * <ul><li>If the complete URL were: http://opendap.org:8080/opendap/nc/fnoc1.nc.dds?lat,lon,time&lat>72.0<br/>
+ * Then the:</li>
+ * <ul>
+ * <li> RequestURL = http://opendap.org:8080/opendap/nc/fnoc1.nc </li>
+ * <li> CollectionName = /opendap/nc/ </li>
+ * <li> DataSetName = fnoc1.nc </li>
+ * <li> DataSourceName = /opendap/nc/fnoc1.nc </li>
+ * <li> RequestSuffix = dds </li>
+ * <li> ConstraintExpression = lat,lon,time&lat>72.0 </li>
+ * </ul>
+ *
+ * <li>If the complete URL were: http://opendap.org:8080/opendap/nc/<br/>
+ * Then the:</li>
+ * <ul>
+ * <li> RequestURL = http://opendap.org:8080/opendap/nc/ </li>
+ * <li> CollectionName = /opendap/nc/ </li>
+ * <li> DataSetName = null </li>
+ * <li> DataSourceName = /opendap/nc/ </li>
+ * <li> RequestSuffix = "" </li>
+ * <li> ConstraintExpression = "" </li>
+ * </ul>
+ * </ul>
+ *
+ * @author Nathan Potter
+ */
+
+public class RequestId {
+    private String id;
+    private UUID uuid;
+
+    public RequestId() {
+        id = "";
+        uuid = UUID.randomUUID();
+    }
+    public RequestId(String id) {
+        this();
+        this.id = id;
+    }
+    public void id(String id){ this.id = id;}
+
+    public String id() {return id;}
+    public UUID uuid() {return uuid;}
+
+    public String getCombined(){ return id + "-" + uuid.toString(); }
+}

--- a/src/opendap/coreServlet/ServletUtil.java
+++ b/src/opendap/coreServlet/ServletUtil.java
@@ -404,6 +404,9 @@ public class ServletUtil {
      * @param reqno The request number.
      * @return A string containing infformation about the passed HttpServletRequest req
      */
+    public static String showRequest(HttpServletRequest req, RequestId reqId) {
+        return showRequest(req, reqId.getCombined());
+    }
     public static String showRequest(HttpServletRequest req, String reqId) {
 
         StringBuilder sb = new StringBuilder();

--- a/src/opendap/gateway/BesGatewayApi.java
+++ b/src/opendap/gateway/BesGatewayApi.java
@@ -30,10 +30,7 @@ import opendap.bes.BESError;
 import opendap.bes.BESResource;
 import opendap.bes.BadConfigurationException;
 import opendap.bes.BesApi;
-import opendap.coreServlet.OPeNDAPException;
-import opendap.coreServlet.ReqInfo;
-import opendap.coreServlet.RequestCache;
-import opendap.coreServlet.Util;
+import opendap.coreServlet.*;
 import opendap.dap.User;
 import opendap.dap4.QueryParameters;
 import opendap.logging.ServletLogUtil;
@@ -130,7 +127,9 @@ public class BesGatewayApi extends BesApi implements Cloneable {
         log.debug("Building request for BES gateway_module request. remoteDataSourceUrl: "+ remoteDataSourceUrl);
         Element e, request = new Element("request", BES.BES_NS);
 
-        request.setAttribute(REQUEST_ID_KEY, RequestCache.getRequestId());
+        RequestId rid = RequestCache.getRequestId();
+        request.setAttribute(BesApi.REQUEST_ID_KEY, rid.id() );
+        request.setAttribute(BesApi.REQUEST_UUID_KEY, rid.uuid().toString() );
 
 
         request.addContent(setContextElement(EXPLICIT_CONTAINERS_CONTEXT,"no"));
@@ -195,7 +194,9 @@ public class BesGatewayApi extends BesApi implements Cloneable {
 
         //String besDataSource = getBES(dataSource).trimPrefix(dataSource);
 
-        request.setAttribute(REQUEST_ID_KEY, RequestCache.getRequestId());
+        RequestId rid = RequestCache.getRequestId();
+        request.setAttribute(BesApi.REQUEST_ID_KEY, rid.id() );
+        request.setAttribute(BesApi.REQUEST_UUID_KEY, rid.uuid().toString() );
 
         /**----------------------------------------------------------------------
          * Added this bit for the cloudy dap experiment - ndp 1/19/17

--- a/src/opendap/logging/ServletLogUtil.java
+++ b/src/opendap/logging/ServletLogUtil.java
@@ -31,6 +31,7 @@ import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.core.joran.spi.JoranException;
 import ch.qos.logback.core.util.StatusPrinter;
 import opendap.PathBuilder;
+import opendap.coreServlet.RequestId;
 import opendap.coreServlet.Scrub;
 import opendap.coreServlet.ServletUtil;
 import org.slf4j.Logger;
@@ -373,11 +374,11 @@ public class ServletLogUtil {
      * @param reqID The request ID, implemented as the request number.
      *
      */
-    public static void logServerAccessStart(HttpServletRequest req, String logName,  String httpVerb, String reqID) {
+    public static void logServerAccessStart(HttpServletRequest req, String logName,  String httpVerb, RequestId reqID) {
 
         HttpSession session = req.getSession(false);
 
-        MDC.put(REQUEST_ID_KEY, reqID);
+        MDC.put(REQUEST_ID_KEY, reqID.getCombined());
         MDC.put(HTTP_VERB_KEY, httpVerb);
         MDC.put(CLIENT_HOST_KEY, req.getRemoteHost());
         MDC.put(SESSION_ID_KEY, (session == null) ? "-" : session.getId());

--- a/src/opendap/ngap/NgapBesApi.java
+++ b/src/opendap/ngap/NgapBesApi.java
@@ -32,10 +32,7 @@ import opendap.bes.BESError;
 import opendap.bes.BESResource;
 import opendap.bes.BadConfigurationException;
 import opendap.bes.BesApi;
-import opendap.coreServlet.OPeNDAPException;
-import opendap.coreServlet.ReqInfo;
-import opendap.coreServlet.RequestCache;
-import opendap.coreServlet.Util;
+import opendap.coreServlet.*;
 import opendap.dap.User;
 import opendap.dap4.QueryParameters;
 import opendap.logging.ServletLogUtil;
@@ -134,7 +131,9 @@ public class NgapBesApi extends BesApi implements Cloneable {
         log.debug("Building request for BES ngap_module request. remoteDataSourceUrl: "+ remoteDataSourceUrl);
         Element e, request = new Element("request", BES.BES_NS);
 
-        request.setAttribute(REQUEST_ID_KEY, RequestCache.getRequestId());
+        RequestId rid = RequestCache.getRequestId();
+        request.setAttribute(BesApi.REQUEST_ID_KEY, rid.id() );
+        request.setAttribute(BesApi.REQUEST_UUID_KEY, rid.uuid().toString() );
 
         request.addContent(setContextElement(EXPLICIT_CONTAINERS_CONTEXT,"no"));
 
@@ -249,7 +248,9 @@ public class NgapBesApi extends BesApi implements Cloneable {
 
         //String besDataSource = getBES(dataSource).trimPrefix(dataSource);
 
-        request.setAttribute(REQUEST_ID_KEY, RequestCache.getRequestId());
+        RequestId rid = RequestCache.getRequestId();
+        request.setAttribute(BesApi.REQUEST_ID_KEY, rid.id() );
+        request.setAttribute(BesApi.REQUEST_UUID_KEY, rid.uuid().toString() );
 
         request.addContent(setContextElement(EXPLICIT_CONTAINERS_CONTEXT,"no"));
 

--- a/src/opendap/ppt/OPeNDAPClient.java
+++ b/src/opendap/ppt/OPeNDAPClient.java
@@ -30,6 +30,7 @@ package opendap.ppt;
 import opendap.bes.BESError;
 import opendap.bes.BesApi;
 import opendap.coreServlet.RequestCache;
+import opendap.coreServlet.RequestId;
 import opendap.io.HyraxStringEncoding;
 import opendap.xml.Util;
 import org.apache.commons.cli.*;
@@ -705,7 +706,9 @@ public class OPeNDAPClient {
 
     public Document getShowStatusRequestDocument(){
         Element request = new Element("request", BES_NS);
-        request.setAttribute(BesApi.REQUEST_ID_KEY, RequestCache.getRequestId() );
+        RequestId rid = RequestCache.getRequestId();
+        request.setAttribute(BesApi.REQUEST_ID_KEY, rid.id() );
+        request.setAttribute(BesApi.REQUEST_UUID_KEY, rid.uuid().toString() );
         request.setAttribute(BesApi.BES_CLIENT_ID_KEY, getID() );
         request.setAttribute(BesApi.BES_CLIENT_CMD_COUNT_KEY, Integer.toString(commandCount) );
         request.addContent(new Element("showStatus"));

--- a/src/opendap/viewers/ViewersServlet.java
+++ b/src/opendap/viewers/ViewersServlet.java
@@ -385,7 +385,7 @@ public class ViewersServlet extends HttpServlet {
     public void doGet(HttpServletRequest req, HttpServletResponse resp) {
 
         RequestCache.open(req);
-        String reqId = RequestCache.getRequestId();
+        RequestId reqId = RequestCache.getRequestId();
 
         ServletLogUtil.logServerAccessStart(req, ServletLogUtil.HYRAX_ACCESS_LOG_ID, "HTTP-GET", reqId);
         LOG.debug(ServletUtil.showRequest(req, reqId));

--- a/src/opendap/w10n/W10nServlet.java
+++ b/src/opendap/w10n/W10nServlet.java
@@ -25,14 +25,7 @@
  */
 package opendap.w10n;
 
-import opendap.coreServlet.ServletUtil;
-import opendap.coreServlet.RequestCache;
-import opendap.coreServlet.ReqInfo;
-import opendap.coreServlet.LicenseManager;
-import opendap.coreServlet.Util;
-import opendap.coreServlet.Debug;
-import opendap.coreServlet.OPeNDAPException;
-import opendap.coreServlet.Scrub;
+import opendap.coreServlet.*;
 import opendap.logging.ServletLogUtil;
 import opendap.logging.Timer;
 import opendap.logging.Procedure;
@@ -122,8 +115,8 @@ public class W10nServlet extends HttpServlet   {
                 }
                 RequestCache.open(request);
 
-                String reqId = RequestCache.getRequestId();
-                ServletLogUtil.logServerAccessStart(request, ServletLogUtil.HYRAX_ACCESS_LOG_ID, "HTTP-GET",reqId );
+                RequestId reqId = RequestCache.getRequestId();
+                ServletLogUtil.logServerAccessStart(request, ServletLogUtil.HYRAX_ACCESS_LOG_ID, "HTTP-GET", reqId );
                 LOG.debug(Util.getMemoryReport());
                 LOG.debug(ServletUtil.showRequest(request, reqId));
                 //log.debug(AwsUtil.probeRequest(this, request));


### PR DESCRIPTION
Refactored the way the request id is handled by adding a new RequestID…class that pairs each new request-id with a new uuid so that we can protect our logs from duplicate request ids