### PR TITLE
Fix sonarqube's pull request interop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,48 +89,48 @@ cache:
 jobs:
   include:
 
-    # - stage: build
-    #   name: "jdk17"
-    #   jdk: openjdk17
-    #   script:
-    #     - export STAGE=build
-    #     - ant -DHYRAX_VERSION=CI-Build -DOLFS_VERSION=CI-Build show server
+    - stage: build
+      name: "jdk17"
+      jdk: openjdk17
+      script:
+        - export STAGE=build
+        - ant -DHYRAX_VERSION=CI-Build -DOLFS_VERSION=CI-Build show server
 
-    # - stage: build
-    #   name: "gradle (jdk17)"
-    #   jdk: openjdk17
-    #   script:
-    #     - export STAGE=build
-    #     - gradle --version
-    #     - gradle tasks
-    #     - gradle war
+    - stage: build
+      name: "gradle (jdk17)"
+      jdk: openjdk17
+      script:
+        - export STAGE=build
+        - gradle --version
+        - gradle tasks
+        - gradle war
 
-    # - stage: disabled
-    #   name: "jdk11"
-    #   jdk: openjdk11
-    #   script:
-    #     - export STAGE=test
-    #     - ant show check
+    - stage: disabled
+      name: "jdk11"
+      jdk: openjdk11
+      script:
+        - export STAGE=test
+        - ant show check
 
-    # # I think doesn't work because the sonarscan/sonarqube 'ant task' s no longer supported. jhrg 1/22/24
-    # - stage: disabled
-    #   name: "sonarscan (jdk17)"
-    #   jdk: openjdk17
-    #   addons: sonarcloud
-    #   script:
-    #     - export STAGE=scan
-    #     - export ANT_OPTS="-Xms256m -Xmx8g"
-    #     - ant -DHYRAX_VERSION=CI-Build -DOLFS_VERSION=CI-Build show server
-    #     - travis_wait 45 ant -Dsonar.token=$SONAR_LOGIN -Dsonar.qualitygate.timeout=2700 -Dsonar.qualitygate.wait=true show sonar
-    #     - curl -s https://sonarcloud.io/api/project_badges/quality_gate?project=opendap-olfs | grep "QUALITY GATE PASS"
+    # I think doesn't work because the sonarscan/sonarqube 'ant task' s no longer supported. jhrg 1/22/24
+    - stage: disabled
+      name: "sonarscan (jdk17)"
+      jdk: openjdk17
+      addons: sonarcloud
+      script:
+        - export STAGE=scan
+        - export ANT_OPTS="-Xms256m -Xmx8g"
+        - ant -DHYRAX_VERSION=CI-Build -DOLFS_VERSION=CI-Build show server
+        - travis_wait 45 ant -Dsonar.token=$SONAR_LOGIN -Dsonar.qualitygate.timeout=2700 -Dsonar.qualitygate.wait=true show sonar
+        - curl -s https://sonarcloud.io/api/project_badges/quality_gate?project=opendap-olfs | grep "QUALITY GATE PASS"
 
-    # - stage: scan
-    #   name: "synk (jdk17)"
-    #   jdk: openjdk17
-    #   script:
-    #     - export STAGE=scan
-    #     - echo $STAGE
-    #     - ./run-snyk.sh
+    - stage: scan
+      name: "synk (jdk17)"
+      jdk: openjdk17
+      script:
+        - export STAGE=scan
+        - echo $STAGE
+        - ./run-snyk.sh
 
     - stage: scan
       name: "gradle sonarscan (jdk17)"
@@ -150,88 +150,88 @@ jobs:
           fi
         - curl -s https://sonarcloud.io/api/project_badges/quality_gate?project=opendap-olfs | grep "QUALITY GATE PASS"
 
-#     - stage: snappah
-#       name: "olfs-snapshot (jdk17)"
-#       jdk: openjdk17
-#       script:
-#         - export STAGE=snappah
-#         - echo "STAGE is ${STAGE}"
-#         - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
-#         - source ./travis/compute_build_tags.sh
-#         - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" -DOLFS_DIST_BASE=olfs-snapshot DISTRO
-#         - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;
-#         - echo "Built Distribution Bundles:"
-#         - ls -l ./build/dist/*.tgz
-#         - echo "Checking ${TRAVIS_BUILD_DIR}/package/"
-#         - ls -l ${TRAVIS_BUILD_DIR}/package/
+    - stage: snappah
+      name: "olfs-snapshot (jdk17)"
+      jdk: openjdk17
+      script:
+        - export STAGE=snappah
+        - echo "STAGE is ${STAGE}"
+        - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
+        - source ./travis/compute_build_tags.sh
+        - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" -DOLFS_DIST_BASE=olfs-snapshot DISTRO
+        - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;
+        - echo "Built Distribution Bundles:"
+        - ls -l ./build/dist/*.tgz
+        - echo "Checking ${TRAVIS_BUILD_DIR}/package/"
+        - ls -l ${TRAVIS_BUILD_DIR}/package/
 
-#     - stage: snappah
-#       name: "olfs-build-number (jdk17)"
-#       jdk: openjdk17
-#       script:
-#         - export STAGE=snappah
-#         - echo "STAGE is ${STAGE}"
-#         - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
-#         - source ./travis/compute_build_tags.sh
-#         - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" DISTRO
-#         - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;
-#         - echo "Built Distribution Bundles:"
-#         - ls -l ./build/dist/*.tgz
-#         - echo "Checking ${TRAVIS_BUILD_DIR}/package/"
-#         - ls -l ${TRAVIS_BUILD_DIR}/package/
+    - stage: snappah
+      name: "olfs-build-number (jdk17)"
+      jdk: openjdk17
+      script:
+        - export STAGE=snappah
+        - echo "STAGE is ${STAGE}"
+        - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
+        - source ./travis/compute_build_tags.sh
+        - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" DISTRO
+        - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;
+        - echo "Built Distribution Bundles:"
+        - ls -l ./build/dist/*.tgz
+        - echo "Checking ${TRAVIS_BUILD_DIR}/package/"
+        - ls -l ${TRAVIS_BUILD_DIR}/package/
 
-#     - stage: snappah
-#       name: "ngap-snapshot (jdk17)"
-#       jdk: openjdk17
-#       script:
-#         - export STAGE=snappah
-#         - echo "STAGE is ${STAGE}"
-#         - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
-#         - source ./travis/compute_build_tags.sh
-#         - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" -DNGAP_DIST_BASE=ngap-snapshot ngap-dist
-#         - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;
-#         - echo "Build Bundles:"
-#         - ls -l ./build/dist/*.tgz
-#         - echo "Checking ${TRAVIS_BUILD_DIR}/package/"
-#         - ls -l ${TRAVIS_BUILD_DIR}/package/
+    - stage: snappah
+      name: "ngap-snapshot (jdk17)"
+      jdk: openjdk17
+      script:
+        - export STAGE=snappah
+        - echo "STAGE is ${STAGE}"
+        - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
+        - source ./travis/compute_build_tags.sh
+        - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" -DNGAP_DIST_BASE=ngap-snapshot ngap-dist
+        - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;
+        - echo "Build Bundles:"
+        - ls -l ./build/dist/*.tgz
+        - echo "Checking ${TRAVIS_BUILD_DIR}/package/"
+        - ls -l ${TRAVIS_BUILD_DIR}/package/
 
-#     - stage: snappah
-#       name: "ngap-build-number (jdk17)"
-#       jdk: openjdk17
-#       script:
-#         - export STAGE=snappah
-#         - echo "STAGE is ${STAGE}"
-#         - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
-#         - source ./travis/compute_build_tags.sh
-#         - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" -DNGAP_DIST_BASE="ngap-${OLFS_BUILD_VERSION}" ngap-dist
-#         - echo "Build Bundles:"
-#         - ls -l ./build/dist/*.tgz
-#         - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;
-#         - echo "Checking ${TRAVIS_BUILD_DIR}/package/"
-#         - ls -l ${TRAVIS_BUILD_DIR}/package/
+    - stage: snappah
+      name: "ngap-build-number (jdk17)"
+      jdk: openjdk17
+      script:
+        - export STAGE=snappah
+        - echo "STAGE is ${STAGE}"
+        - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
+        - source ./travis/compute_build_tags.sh
+        - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" -DNGAP_DIST_BASE="ngap-${OLFS_BUILD_VERSION}" ngap-dist
+        - echo "Build Bundles:"
+        - ls -l ./build/dist/*.tgz
+        - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;
+        - echo "Checking ${TRAVIS_BUILD_DIR}/package/"
+        - ls -l ${TRAVIS_BUILD_DIR}/package/
 
-#     # The hyrax-docker-trigger stage grabs the hyrax-docker project, sets the current
-#     # snapshot time and pushes the result to GitHub. This push triggers TravisCI
-#     # to build the Docker containers for all the Hyrax snapshot products.
-#     # I moved this into its own stage instead of after_deploy so that it would
-#     # reliably run once after everything else worked. -ndp 3/10/21
-#     - stage: hyrax-docker-trigger
-#       name: "Triggering hyrax-docker snapshot build"
-#       script:
-#         - export STAGE=hyrax-docker
-#         - echo $STAGE
-#         - source ./travis/compute_build_tags.sh
-#         - ./travis/trigger-hyrax-docker.sh
+    # The hyrax-docker-trigger stage grabs the hyrax-docker project, sets the current
+    # snapshot time and pushes the result to GitHub. This push triggers TravisCI
+    # to build the Docker containers for all the Hyrax snapshot products.
+    # I moved this into its own stage instead of after_deploy so that it would
+    # reliably run once after everything else worked. -ndp 3/10/21
+    - stage: hyrax-docker-trigger
+      name: "Triggering hyrax-docker snapshot build"
+      script:
+        - export STAGE=hyrax-docker
+        - echo $STAGE
+        - source ./travis/compute_build_tags.sh
+        - ./travis/trigger-hyrax-docker.sh
 
-# # The "deploy" section copies the snapshot build product to our S3 bucket
-# deploy:
-#   - provider: s3
-#     edge: true
-#     access_key_id: $AWS_ACCESS_KEY_ID
-#     secret_access_key: $AWS_SECRET_ACCESS_KEY
-#     bucket: opendap.travis.build
-#     skip_cleanup: true
-#     local_dir: $TRAVIS_BUILD_DIR/package
-#     on:
-#       all_branches: true
-#       condition: $STAGE =~ ^snappah$
+# The "deploy" section copies the snapshot build product to our S3 bucket
+deploy:
+  - provider: s3
+    edge: true
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    bucket: opendap.travis.build
+    skip_cleanup: true
+    local_dir: $TRAVIS_BUILD_DIR/package
+    on:
+      all_branches: true
+      condition: $STAGE =~ ^snappah$

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ install:
   - npm install -g snyk-gradle-plugin
 
 stages:
-  # - name: build
+  - name: build
   - name: test
   - name: scan
   - name: snappah
@@ -89,48 +89,48 @@ cache:
 jobs:
   include:
 
-    - stage: build
-      name: "jdk17"
-      jdk: openjdk17
-      script:
-        - export STAGE=build
-        - ant -DHYRAX_VERSION=CI-Build -DOLFS_VERSION=CI-Build show server
+    # - stage: build
+    #   name: "jdk17"
+    #   jdk: openjdk17
+    #   script:
+    #     - export STAGE=build
+    #     - ant -DHYRAX_VERSION=CI-Build -DOLFS_VERSION=CI-Build show server
 
-    - stage: build
-      name: "gradle (jdk17)"
-      jdk: openjdk17
-      script:
-        - export STAGE=build
-        - gradle --version
-        - gradle tasks
-        - gradle war
+    # - stage: build
+    #   name: "gradle (jdk17)"
+    #   jdk: openjdk17
+    #   script:
+    #     - export STAGE=build
+    #     - gradle --version
+    #     - gradle tasks
+    #     - gradle war
 
-    - stage: disabled
-      name: "jdk11"
-      jdk: openjdk11
-      script:
-        - export STAGE=test
-        - ant show check
+    # - stage: disabled
+    #   name: "jdk11"
+    #   jdk: openjdk11
+    #   script:
+    #     - export STAGE=test
+    #     - ant show check
 
-    # I think doesn't work because the sonarscan/sonarqube 'ant task' s no longer supported. jhrg 1/22/24
-    - stage: disabled
-      name: "sonarscan (jdk17)"
-      jdk: openjdk17
-      addons: sonarcloud
-      script:
-        - export STAGE=scan
-        - export ANT_OPTS="-Xms256m -Xmx8g"
-        - ant -DHYRAX_VERSION=CI-Build -DOLFS_VERSION=CI-Build show server
-        - travis_wait 45 ant -Dsonar.token=$SONAR_LOGIN -Dsonar.qualitygate.timeout=2700 -Dsonar.qualitygate.wait=true show sonar
-        - curl -s https://sonarcloud.io/api/project_badges/quality_gate?project=opendap-olfs | grep "QUALITY GATE PASS"
+    # # I think doesn't work because the sonarscan/sonarqube 'ant task' s no longer supported. jhrg 1/22/24
+    # - stage: disabled
+    #   name: "sonarscan (jdk17)"
+    #   jdk: openjdk17
+    #   addons: sonarcloud
+    #   script:
+    #     - export STAGE=scan
+    #     - export ANT_OPTS="-Xms256m -Xmx8g"
+    #     - ant -DHYRAX_VERSION=CI-Build -DOLFS_VERSION=CI-Build show server
+    #     - travis_wait 45 ant -Dsonar.token=$SONAR_LOGIN -Dsonar.qualitygate.timeout=2700 -Dsonar.qualitygate.wait=true show sonar
+    #     - curl -s https://sonarcloud.io/api/project_badges/quality_gate?project=opendap-olfs | grep "QUALITY GATE PASS"
 
-    - stage: scan
-      name: "synk (jdk17)"
-      jdk: openjdk17
-      script:
-        - export STAGE=scan
-        - echo $STAGE
-        - ./run-snyk.sh
+    # - stage: scan
+    #   name: "synk (jdk17)"
+    #   jdk: openjdk17
+    #   script:
+    #     - export STAGE=scan
+    #     - echo $STAGE
+    #     - ./run-snyk.sh
 
     - stage: scan
       name: "gradle sonarscan (jdk17)"
@@ -145,88 +145,88 @@ jobs:
         - travis_wait 30 gradle sonar -Dsonar.token=$SONAR_LOGIN -Dsonar.qualitygate.timeout=1800 -Dsonar.qualitygate.wait=true -Dsonar.branch.name="$SONAR_BRANCH_NAME"
         - curl -s https://sonarcloud.io/api/project_badges/quality_gate?project=opendap-olfs | grep "QUALITY GATE PASS"
 
-    - stage: snappah
-      name: "olfs-snapshot (jdk17)"
-      jdk: openjdk17
-      script:
-        - export STAGE=snappah
-        - echo "STAGE is ${STAGE}"
-        - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
-        - source ./travis/compute_build_tags.sh
-        - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" -DOLFS_DIST_BASE=olfs-snapshot DISTRO
-        - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;
-        - echo "Built Distribution Bundles:"
-        - ls -l ./build/dist/*.tgz
-        - echo "Checking ${TRAVIS_BUILD_DIR}/package/"
-        - ls -l ${TRAVIS_BUILD_DIR}/package/
+#     - stage: snappah
+#       name: "olfs-snapshot (jdk17)"
+#       jdk: openjdk17
+#       script:
+#         - export STAGE=snappah
+#         - echo "STAGE is ${STAGE}"
+#         - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
+#         - source ./travis/compute_build_tags.sh
+#         - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" -DOLFS_DIST_BASE=olfs-snapshot DISTRO
+#         - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;
+#         - echo "Built Distribution Bundles:"
+#         - ls -l ./build/dist/*.tgz
+#         - echo "Checking ${TRAVIS_BUILD_DIR}/package/"
+#         - ls -l ${TRAVIS_BUILD_DIR}/package/
 
-    - stage: snappah
-      name: "olfs-build-number (jdk17)"
-      jdk: openjdk17
-      script:
-        - export STAGE=snappah
-        - echo "STAGE is ${STAGE}"
-        - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
-        - source ./travis/compute_build_tags.sh
-        - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" DISTRO
-        - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;
-        - echo "Built Distribution Bundles:"
-        - ls -l ./build/dist/*.tgz
-        - echo "Checking ${TRAVIS_BUILD_DIR}/package/"
-        - ls -l ${TRAVIS_BUILD_DIR}/package/
+#     - stage: snappah
+#       name: "olfs-build-number (jdk17)"
+#       jdk: openjdk17
+#       script:
+#         - export STAGE=snappah
+#         - echo "STAGE is ${STAGE}"
+#         - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
+#         - source ./travis/compute_build_tags.sh
+#         - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" DISTRO
+#         - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;
+#         - echo "Built Distribution Bundles:"
+#         - ls -l ./build/dist/*.tgz
+#         - echo "Checking ${TRAVIS_BUILD_DIR}/package/"
+#         - ls -l ${TRAVIS_BUILD_DIR}/package/
 
-    - stage: snappah
-      name: "ngap-snapshot (jdk17)"
-      jdk: openjdk17
-      script:
-        - export STAGE=snappah
-        - echo "STAGE is ${STAGE}"
-        - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
-        - source ./travis/compute_build_tags.sh
-        - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" -DNGAP_DIST_BASE=ngap-snapshot ngap-dist
-        - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;
-        - echo "Build Bundles:"
-        - ls -l ./build/dist/*.tgz
-        - echo "Checking ${TRAVIS_BUILD_DIR}/package/"
-        - ls -l ${TRAVIS_BUILD_DIR}/package/
+#     - stage: snappah
+#       name: "ngap-snapshot (jdk17)"
+#       jdk: openjdk17
+#       script:
+#         - export STAGE=snappah
+#         - echo "STAGE is ${STAGE}"
+#         - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
+#         - source ./travis/compute_build_tags.sh
+#         - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" -DNGAP_DIST_BASE=ngap-snapshot ngap-dist
+#         - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;
+#         - echo "Build Bundles:"
+#         - ls -l ./build/dist/*.tgz
+#         - echo "Checking ${TRAVIS_BUILD_DIR}/package/"
+#         - ls -l ${TRAVIS_BUILD_DIR}/package/
 
-    - stage: snappah
-      name: "ngap-build-number (jdk17)"
-      jdk: openjdk17
-      script:
-        - export STAGE=snappah
-        - echo "STAGE is ${STAGE}"
-        - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
-        - source ./travis/compute_build_tags.sh
-        - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" -DNGAP_DIST_BASE="ngap-${OLFS_BUILD_VERSION}" ngap-dist
-        - echo "Build Bundles:"
-        - ls -l ./build/dist/*.tgz
-        - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;
-        - echo "Checking ${TRAVIS_BUILD_DIR}/package/"
-        - ls -l ${TRAVIS_BUILD_DIR}/package/
+#     - stage: snappah
+#       name: "ngap-build-number (jdk17)"
+#       jdk: openjdk17
+#       script:
+#         - export STAGE=snappah
+#         - echo "STAGE is ${STAGE}"
+#         - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
+#         - source ./travis/compute_build_tags.sh
+#         - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" -DNGAP_DIST_BASE="ngap-${OLFS_BUILD_VERSION}" ngap-dist
+#         - echo "Build Bundles:"
+#         - ls -l ./build/dist/*.tgz
+#         - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;
+#         - echo "Checking ${TRAVIS_BUILD_DIR}/package/"
+#         - ls -l ${TRAVIS_BUILD_DIR}/package/
 
-    # The hyrax-docker-trigger stage grabs the hyrax-docker project, sets the current
-    # snapshot time and pushes the result to GitHub. This push triggers TravisCI
-    # to build the Docker containers for all the Hyrax snapshot products.
-    # I moved this into its own stage instead of after_deploy so that it would
-    # reliably run once after everything else worked. -ndp 3/10/21
-    - stage: hyrax-docker-trigger
-      name: "Triggering hyrax-docker snapshot build"
-      script:
-        - export STAGE=hyrax-docker
-        - echo $STAGE
-        - source ./travis/compute_build_tags.sh
-        - ./travis/trigger-hyrax-docker.sh
+#     # The hyrax-docker-trigger stage grabs the hyrax-docker project, sets the current
+#     # snapshot time and pushes the result to GitHub. This push triggers TravisCI
+#     # to build the Docker containers for all the Hyrax snapshot products.
+#     # I moved this into its own stage instead of after_deploy so that it would
+#     # reliably run once after everything else worked. -ndp 3/10/21
+#     - stage: hyrax-docker-trigger
+#       name: "Triggering hyrax-docker snapshot build"
+#       script:
+#         - export STAGE=hyrax-docker
+#         - echo $STAGE
+#         - source ./travis/compute_build_tags.sh
+#         - ./travis/trigger-hyrax-docker.sh
 
-# The "deploy" section copies the snapshot build product to our S3 bucket
-deploy:
-  - provider: s3
-    edge: true
-    access_key_id: $AWS_ACCESS_KEY_ID
-    secret_access_key: $AWS_SECRET_ACCESS_KEY
-    bucket: opendap.travis.build
-    skip_cleanup: true
-    local_dir: $TRAVIS_BUILD_DIR/package
-    on:
-      all_branches: true
-      condition: $STAGE =~ ^snappah$
+# # The "deploy" section copies the snapshot build product to our S3 bucket
+# deploy:
+#   - provider: s3
+#     edge: true
+#     access_key_id: $AWS_ACCESS_KEY_ID
+#     secret_access_key: $AWS_SECRET_ACCESS_KEY
+#     bucket: opendap.travis.build
+#     skip_cleanup: true
+#     local_dir: $TRAVIS_BUILD_DIR/package
+#     on:
+#       all_branches: true
+#       condition: $STAGE =~ ^snappah$

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,11 +138,16 @@ jobs:
       addons: sonarcloud
       script:
         - export STAGE=scan
-        # Various edits to the build.gradle file to get this to work. jhrg 1/22/24
-        # - travis_wait 30 gradle buildDists sonarqube -Dsonar.token=$SONAR_LOGIN -Dsonar.qualitygate.timeout=1800 -Dsonar.qualitygate.wait=true
-        - export SONAR_BRANCH_NAME="$TRAVIS_PULL_REQUEST_BRANCH"
-        - if test -z "$SONAR_BRANCH_NAME"; then export SONAR_BRANCH_NAME="$TRAVIS_BRANCH"; fi
-        - travis_wait 30 gradle sonar -Dsonar.token=$SONAR_LOGIN -Dsonar.qualitygate.timeout=1800 -Dsonar.qualitygate.wait=true -Dsonar.branch.name="$SONAR_BRANCH_NAME"
+        - | 
+          if test -z "$TRAVIS_PULL_REQUEST_BRANCH"; then 
+            # If no travis pull request branch was found, this is not a pull request!
+            travis_wait 30 gradle sonar -Dsonar.token=$SONAR_LOGIN -Dsonar.qualitygate.timeout=1800 -Dsonar.qualitygate.wait=true -Dsonar.branch.name="$TRAVIS_BRANCH"
+          else
+            # If that variable *was* found, we need to pass in the three variables that let sonar know this is a pull request
+            # https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/pull-request-analysis/setting-up-the-pull-request-analysis/#setup-pull-request-parameters
+            # Because Travis's `TRAVIS_BRANCH` is the name of the target branch **when Travis is triggered by a pull request**, that is the pullrequest.base
+            travis_wait 30 gradle sonar -Dsonar.token=$SONAR_LOGIN -Dsonar.qualitygate.timeout=1800 -Dsonar.qualitygate.wait=true -Dsonar.pullrequest.key="$TRAVIS_PULL_REQUEST" -Dsonar.pullrequest.branch="$TRAVIS_PULL_REQUEST_BRANCH" sonar.pullrequest.base="$TRAVIS_BRANCH"
+          fi
         - curl -s https://sonarcloud.io/api/project_badges/quality_gate?project=opendap-olfs | grep "QUALITY GATE PASS"
 
 #     - stage: snappah

--- a/.travis.yml
+++ b/.travis.yml
@@ -146,7 +146,7 @@ jobs:
             # If that variable *was* found, we need to pass in the three variables that let sonar know this is a pull request
             # https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/pull-request-analysis/setting-up-the-pull-request-analysis/#setup-pull-request-parameters
             # Because Travis's `TRAVIS_BRANCH` is the name of the target branch **when Travis is triggered by a pull request**, that is the pullrequest.base
-            travis_wait 30 gradle sonar -Dsonar.token=$SONAR_LOGIN -Dsonar.qualitygate.timeout=1800 -Dsonar.qualitygate.wait=true -Dsonar.pullrequest.key="$TRAVIS_PULL_REQUEST" -Dsonar.pullrequest.branch="$TRAVIS_PULL_REQUEST_BRANCH" sonar.pullrequest.base="$TRAVIS_BRANCH"
+            travis_wait 30 gradle sonar -Dsonar.token=$SONAR_LOGIN -Dsonar.qualitygate.timeout=1800 -Dsonar.qualitygate.wait=true -Dsonar.pullrequest.key="$TRAVIS_PULL_REQUEST" -Dsonar.pullrequest.branch="$TRAVIS_PULL_REQUEST_BRANCH" -Dsonar.pullrequest.base="$TRAVIS_BRANCH"
           fi
         - curl -s https://sonarcloud.io/api/project_badges/quality_gate?project=opendap-olfs | grep "QUALITY GATE PASS"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -142,7 +142,7 @@ jobs:
         # - travis_wait 30 gradle buildDists sonarqube -Dsonar.token=$SONAR_LOGIN -Dsonar.qualitygate.timeout=1800 -Dsonar.qualitygate.wait=true
         - export SONAR_BRANCH_NAME="$TRAVIS_PULL_REQUEST_BRANCH"
         - if test -z "$SONAR_BRANCH_NAME"; then export SONAR_BRANCH_NAME="$TRAVIS_BRANCH"; fi
-        - travis_wait 30 gradle sonar -Dsonar.login=$SONAR_LOGIN -Dsonar.qualitygate.timeout=1800 -Dsonar.qualitygate.wait=true -Dsonar.branch.name="$SONAR_BRANCH_NAME"
+        - travis_wait 30 gradle sonar -Dsonar.token=$SONAR_LOGIN -Dsonar.qualitygate.timeout=1800 -Dsonar.qualitygate.wait=true -Dsonar.branch.name="$SONAR_BRANCH_NAME"
         - curl -s https://sonarcloud.io/api/project_badges/quality_gate?project=opendap-olfs | grep "QUALITY GATE PASS"
 
     - stage: snappah

--- a/.travis.yml
+++ b/.travis.yml
@@ -139,6 +139,7 @@ jobs:
       script:
         - export STAGE=scan
         - | 
+          # multiline build instructions incoming!
           if test -z "$TRAVIS_PULL_REQUEST_BRANCH"; then 
             # If no travis pull request branch was found, this is not a pull request!
             travis_wait 30 gradle sonar -Dsonar.token=$SONAR_LOGIN -Dsonar.qualitygate.timeout=1800 -Dsonar.qualitygate.wait=true -Dsonar.branch.name="$TRAVIS_BRANCH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ install:
   - npm install -g snyk-gradle-plugin
 
 stages:
-  - name: build
+  # - name: build
   - name: test
   - name: scan
   - name: snappah

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ plugins {
     id 'eclipse'
     id 'idea'
     // Updated the version from 3.3. Needed to get the sonar target working. jhrg 1/22/24
-    id 'org.sonarqube' version '4.4.1.3373'
+    id 'org.sonarqube' version '6.2.0.5505'
 }
 
 // While these properties are inside a 'sonarqube' block, the task is called 'sonar.' jhrg 1/22/24

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ sonarqube {
                                     "src/opendap/**/*Test.java"
         property "sonar.java.binaries", "build"
         property "sonar.java.libraries", "lib/*.jar"
+        property "sonar.verbose", "true"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ plugins {
     id 'war'
     id 'eclipse'
     id 'idea'
-    // Updated the version from 3.3. Needed to get the sonar target working. jhrg 1/22/24
     id 'org.sonarqube' version '6.2.0.5505'
 }
 
@@ -44,7 +43,6 @@ sonarqube {
                                     "src/opendap/**/*Test.java"
         property "sonar.java.binaries", "build"
         property "sonar.java.libraries", "lib/*.jar"
-        property "sonar.verbose", "true"
     }
 }
 

--- a/src/opendap/auth/UrsIdPTest.java
+++ b/src/opendap/auth/UrsIdPTest.java
@@ -26,8 +26,6 @@
 
 package opendap.auth;
 
-import opendap.auth.UrsIdP;
-
 import com.auth0.jwk.InvalidPublicKeyException;
 import com.google.gson.JsonParseException;
 import java.math.BigInteger;

--- a/src/opendap/ngap/NgapDmrppResponder.java
+++ b/src/opendap/ngap/NgapDmrppResponder.java
@@ -28,7 +28,6 @@ package opendap.ngap;
 
 import opendap.bes.BesApi;
 import opendap.bes.Version;
-import opendap.ngap.NgapBesApi;
 import opendap.bes.dap4Responders.Dap4Responder;
 import opendap.bes.dap4Responders.MediaType;
 import opendap.coreServlet.*;


### PR DESCRIPTION
As of #229, sonarqube knows about individual branches; as of this PR, it now knows them as *pull requests* rather than arbitrary branches---which then triggers the sonarqubecloud bot's comments on PRs with their reports. (See an example of this below! Note that it was not happening in previous PRs in this repo.)

Why do we need to set this up manually, while it happens automatically for other repos in this organization (bes, libdap4, etc)? Great question. Current theory is that it is because we are reporting through the gradle sonarcube plugin, rather than reporting back directly. 🤷 At any rate, this manual configuration in this repo seems to correct the PR <-> sonarqube interop.