### PR TITLE
Remove branch var from non-PR sonar job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,7 +142,7 @@ jobs:
           # multiline build instructions incoming!
           if test -z "$TRAVIS_PULL_REQUEST_BRANCH"; then 
             # If no travis pull request branch was found, this is not a pull request!
-            travis_wait 30 gradle sonar -Dsonar.token=$SONAR_LOGIN -Dsonar.qualitygate.timeout=1800 -Dsonar.qualitygate.wait=true -Dsonar.branch.name="$TRAVIS_BRANCH"
+            travis_wait 30 gradle sonar -Dsonar.token=$SONAR_LOGIN -Dsonar.qualitygate.timeout=1800 -Dsonar.qualitygate.wait=true
           else
             # If that variable *was* found, we need to pass in the three variables that let sonar know this is a pull request
             # https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/pull-request-analysis/setting-up-the-pull-request-analysis/#setup-pull-request-parameters


### PR DESCRIPTION
...another shot in the dark to try to fix the missing sonarqube dashboard. We won't know if it worked until it merges down to master.