### PR TITLE
Downgrade Travis's gradle version back to 8.14.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -156,6 +156,12 @@ jobs:
             travis_wait 30 gradle sonar -Dsonar.token=$SONAR_LOGIN -Dsonar.qualitygate.timeout=1800 -Dsonar.qualitygate.wait=true -Dsonar.pullrequest.key="$TRAVIS_PULL_REQUEST" -Dsonar.pullrequest.branch="$TRAVIS_PULL_REQUEST_BRANCH" -Dsonar.pullrequest.base="$TRAVIS_BRANCH"
           fi
         - curl -s https://sonarcloud.io/api/project_badges/quality_gate?project=opendap-olfs | grep "QUALITY GATE PASS"
+      before_install:
+        - wget http://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+        - unzip -qq gradle-8.14.3-bin.zip
+        - export GRADLE_HOME=$PWD/gradle-8.14.3
+        - export PATH=$GRADLE_HOME/bin:$PATH
+        - gradle -v
 
     - stage: snappah
       name: "olfs-snapshot (jdk17)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -155,7 +155,7 @@ jobs:
             # Because Travis's `TRAVIS_BRANCH` is the name of the target branch **when Travis is triggered by a pull request**, that is the pullrequest.base
             travis_wait 30 gradle sonar -Dsonar.token=$SONAR_LOGIN -Dsonar.qualitygate.timeout=1800 -Dsonar.qualitygate.wait=true -Dsonar.pullrequest.key="$TRAVIS_PULL_REQUEST" -Dsonar.pullrequest.branch="$TRAVIS_PULL_REQUEST_BRANCH" -Dsonar.pullrequest.base="$TRAVIS_BRANCH"
           fi
-          curl -s https://sonarcloud.io/api/project_badges/quality_gate?project=opendap-olfs | grep "QUALITY GATE PASS"
+        - curl -s https://sonarcloud.io/api/project_badges/quality_gate?project=opendap-olfs | grep "QUALITY GATE PASS"
 
     - stage: snappah
       name: "olfs-snapshot (jdk17)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,12 @@ jobs:
         - gradle --version
         - gradle tasks
         - gradle war
+      before_install:
+        - wget http://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+        - unzip -qq gradle-8.14.3-bin.zip
+        - export GRADLE_HOME=$PWD/gradle-8.14.3
+        - export PATH=$GRADLE_HOME/bin:$PATH
+        - gradle -v
 
     - stage: disabled
       name: "jdk11"

--- a/.travis.yml
+++ b/.travis.yml
@@ -155,7 +155,7 @@ jobs:
             # Because Travis's `TRAVIS_BRANCH` is the name of the target branch **when Travis is triggered by a pull request**, that is the pullrequest.base
             travis_wait 30 gradle sonar -Dsonar.token=$SONAR_LOGIN -Dsonar.qualitygate.timeout=1800 -Dsonar.qualitygate.wait=true -Dsonar.pullrequest.key="$TRAVIS_PULL_REQUEST" -Dsonar.pullrequest.branch="$TRAVIS_PULL_REQUEST_BRANCH" -Dsonar.pullrequest.base="$TRAVIS_BRANCH"
           fi
-        - curl -s https://sonarcloud.io/api/project_badges/quality_gate?project=opendap-olfs | grep "QUALITY GATE PASS"
+          curl -s https://sonarcloud.io/api/project_badges/quality_gate?project=opendap-olfs | grep "QUALITY GATE PASS"
 
     - stage: snappah
       name: "olfs-snapshot (jdk17)"


### PR DESCRIPTION
Gradle released a new major version on 8/5/2025, which has broken our olfs build.

Until we fix our gradle setup to support the updated release, downgrade gradle to a known working version for our build.