### PR TITLE
Refactored the show target and it's usage in our Ant production rules.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -157,7 +157,7 @@ jobs:
         - echo "STAGE is ${STAGE}"
         - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
         - source ./travis/compute_build_tags.sh
-        - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" -DOLFS_DIST_BASE=olfs-snapshot DISTRO
+        - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" -DOLFS_DIST_BASE=olfs-snapshot show DISTRO
         - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;
         - echo "Built Distribution Bundles:"
         - ls -l ./build/dist/*.tgz
@@ -172,7 +172,7 @@ jobs:
         - echo "STAGE is ${STAGE}"
         - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
         - source ./travis/compute_build_tags.sh
-        - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" DISTRO
+        - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" show DISTRO
         - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;
         - echo "Built Distribution Bundles:"
         - ls -l ./build/dist/*.tgz
@@ -187,7 +187,7 @@ jobs:
         - echo "STAGE is ${STAGE}"
         - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
         - source ./travis/compute_build_tags.sh
-        - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" -DNGAP_DIST_BASE=ngap-snapshot ngap-dist
+        - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" -DNGAP_DIST_BASE=ngap-snapshot show ngap-dist
         - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;
         - echo "Build Bundles:"
         - ls -l ./build/dist/*.tgz
@@ -202,7 +202,7 @@ jobs:
         - echo "STAGE is ${STAGE}"
         - test -d $TRAVIS_BUILD_DIR/package || mkdir $TRAVIS_BUILD_DIR/package
         - source ./travis/compute_build_tags.sh
-        - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" -DNGAP_DIST_BASE="ngap-${OLFS_BUILD_VERSION}" ngap-dist
+        - ant -DHYRAX_VERSION="${HYRAX_BUILD_VERSION}" -DOLFS_VERSION="${OLFS_BUILD_VERSION}" -DNGAP_DIST_BASE="ngap-${OLFS_BUILD_VERSION}" show ngap-dist
         - echo "Build Bundles:"
         - ls -l ./build/dist/*.tgz
         - cp ./build/dist/*.tgz $TRAVIS_BUILD_DIR/package/;

--- a/build.xml
+++ b/build.xml
@@ -143,57 +143,74 @@
         <echo level="info" message="##########################################################"/>
         <echo level="info" message="# Build Settings"/>
         <echo level="info" message="#"/>
-        <echo level="info" message="                  Project Name: ${ant.project.name}"/>
-        <echo level="info" message="                  Project File: ${ant.file}"/>
-        <echo level="info" message="                 Hyrax Version: ${HYRAX_VERSION}"/>
-        <echo level="info" message="                  OLFS Version: ${OLFS_VERSION}"/>
-        <echo level="info" message="                  NGAP Version: ${NGAP_VERSION}"/>
-        <echo level="info" message="                   WCS Version: ${WCS_VERSION}"/>
-        <echo level="info" message="            Deployment Context: ${DEPLOYMENT_CONTEXT}"/>
-        <echo level="info" message="       NGAP Deployment Context: ${NGAP_DEPLOYMENT_CONTEXT}"/>
-        <echo level="info" message=""/>
-        <echo level="info" message="Project Directories:"/>
-        <echo level="info" message="                src.dir: ${src.dir}"/>
-        <echo level="info" message="                doc.dir: ${doc.dir}"/>
-        <echo level="info" message="                lib.dir: ${lib.dir}"/>
-        <echo level="info" message="          resources.dir: ${resources.dir}"/>
-        <echo level="info" message=""/>
-        <echo level="info" message="Build Directories:"/>
-        <echo level="info" message="              build.dir: ${build.dir}"/>
-        <echo level="info" message="          build.classes: ${build.classes}"/>
-        <echo level="info" message="              build.doc: ${build.docs}"/>
-        <echo level="info" message="        build.resources: ${build.hyrax.resources}"/>
-        <echo level="info" message=""/>
-        <echo level="info" message="Ant Properties:"/>
-        <echo level="info" message="               ant.file: ${ant.file}"/>
-        <echo level="info" message="               ant.home: ${ant.home}"/>
-        <echo level="info" message="       ant.java.version: ${ant.java.version}"/>
-        <echo level="info" message="       ant.project.name: ${ant.project.name}"/>
-        <echo level="info" message="            ant.version: ${ant.version}"/>
-        <echo level="info" message="                basedir: ${basedir}"/>
-        <echo level="info" message="              user.name: ${user.name}"/>
-        <echo level="info" message="              user.home: ${user.home}"/>
-        <echo level="info" message="              java.home: ${java.home}"/>
-        <echo level="info" message="           java.version: ${java.version}"/>
-        <echo level="info" message=""/>
-        <echo level="info" message="Distribution Targets: "/>
-        <echo level="info" message="            WEBAPP_DIST: ${WEBAPP_DIST}"/>
-        <echo level="info" message="               SRC_DIST: ${SRC_DIST}"/>
-        <echo level="info" message="               DOC_DIST: ${DOC_DIST}"/>
-        <echo level="info" message="               OLFS_LIB: ${OLFS_LIB}"/>
-        <echo level="info" message=""/>
-        <echo level="info" message="----------------------------------------------------------"/>
-        <echo level="info" message="       Operating System: ${os.name}"/>
-        <echo level="info" message="            Arcitecture: ${os.arch}"/>
-        <echo level="info" message="                Version: ${os.version}"/>
-        <echo level="info" message="       sun.java.command: ${sun.java.command}"/>
-        <echo level="info" message="               ANT_OPTS: ${ANT_OPTS}"/>
-        <echo level="info" message="Calling echoproperties task"/>
-        <echoproperties  />
-        <echo level="info" message=""/>
+        <echo level="info" message="#    Project Name: ${ant.project.name}"/>
+        <echo level="info" message="#    Project File: ${ant.file}"/>
+        <echo level="info" message="#"/>
+        <echo level="info" message="#----------------------------------------------------------"/>
+        <echo level="info" message="# Versions and Contexts:"/>
+        <echo level="info" message="#               Hyrax Version: ${HYRAX_VERSION}"/>
+        <echo level="info" message="#                OLFS Version: ${OLFS_VERSION}"/>
+        <echo level="info" message="#                NGAP Version: ${NGAP_VERSION}"/>
+        <echo level="info" message="#                 WCS Version: ${WCS_VERSION}"/>
+        <echo level="info" message="#          Deployment Context: ${DEPLOYMENT_CONTEXT}"/>
+        <echo level="info" message="#     NGAP Deployment Context: ${NGAP_DEPLOYMENT_CONTEXT}"/>
+        <echo level="info" message="#"/>
+        <echo level="info" message="#----------------------------------------------------------"/>
+        <echo level="info" message="# Project Directories:"/>
+        <echo level="info" message="#           src.dir: ${src.dir}"/>
+        <echo level="info" message="#           doc.dir: ${doc.dir}"/>
+        <echo level="info" message="#           lib.dir: ${lib.dir}"/>
+        <echo level="info" message="#     resources.dir: ${resources.dir}"/>
+        <echo level="info" message="#"/>
+        <echo level="info" message="#----------------------------------------------------------"/>
+        <echo level="info" message="# Build Directories:"/>
+        <echo level="info" message="#           build.dir: ${build.dir}"/>
+        <echo level="info" message="#       build.classes: ${build.classes}"/>
+        <echo level="info" message="#           build.doc: ${build.docs}"/>
+        <echo level="info" message="#     build.resources: ${build.hyrax.resources}"/>
+        <echo level="info" message="#"/>
+        <echo level="info" message="#----------------------------------------------------------"/>
+        <echo level="info" message="# Ant Situation:"/>
+        <echo level="info" message="#             ant.file: ${ant.file}"/>
+        <echo level="info" message="#             ant.home: ${ant.home}"/>
+        <echo level="info" message="#     ant.java.version: ${ant.java.version}"/>
+        <echo level="info" message="#     ant.project.name: ${ant.project.name}"/>
+        <echo level="info" message="#          ant.version: ${ant.version}"/>
+        <echo level="info" message="#              basedir: ${basedir}"/>
+        <echo level="info" message="#            user.name: ${user.name}"/>
+        <echo level="info" message="#            user.home: ${user.home}"/>
+        <echo level="info" message="#            java.home: ${java.home}"/>
+        <echo level="info" message="#         java.version: ${java.version}"/>
+        <echo level="info" message="#"/>
+        <echo level="info" message="#----------------------------------------------------------"/>
+        <echo level="info" message="# Distribution Targets: "/>
+        <echo level="info" message="#     WEBAPP_DIST: ${WEBAPP_DIST}"/>
+        <echo level="info" message="#        SRC_DIST: ${SRC_DIST}"/>
+        <echo level="info" message="#        DOC_DIST: ${DOC_DIST}"/>
+        <echo level="info" message="#        OLFS_LIB: ${OLFS_LIB}"/>
+        <echo level="info" message="#"/>
+        <echo level="info" message="#----------------------------------------------------------"/>
+        <echo level="info" message="# System:"/>
+        <echo level="info" message="#     Operating System: ${os.name}"/>
+        <echo level="info" message="#          Arcitecture: ${os.arch}"/>
+        <echo level="info" message="#              Version: ${os.version}"/>
+        <echo level="info" message="#     sun.java.command: ${sun.java.command}"/>
+        <echo level="info" message="#             ANT_OPTS: ${ANT_OPTS}"/>
         <echo level="info" message="##########################################################"/>
 
     </target>
+
+
+    <target name="showAntProperties" description="Show build settings.">
+        <echo level="info" message="##########################################################"/>
+        <echo level="info" message="# ANT Properties"/>
+        <echo level="info" message="# Calling the ANT echoproperties task"/>
+        <echoproperties  />
+        <echo level="info" message="#"/>
+        <echo level="info" message="##########################################################"/>
+    </target>
+
+    <target name="showAll" description="Show Me." depends="show,showAntProperties" />
 
 
     <!-- ################################################################# -->


### PR DESCRIPTION
I needed to decouple parts of the show command so it could be used to better understand our build target state situation.

This is:
* A change of human readable output formatting for the show target.
*  Breaking the show target up for better control of output content.
* Adding show target  calls to the production rules for our builds to better see the situation for each.