### PR TITLE
enabling multi os travis build for hyrax-docker

### DIFF
--- a/travis/trigger-hyrax-docker.sh
+++ b/travis/trigger-hyrax-docker.sh
@@ -65,9 +65,12 @@ echo "TOMCAT_MAJOR_VERSION: $TOMCAT_MAJOR_VERSION" >> "$BUILD_RECIPE_FILE"
 echo "${BES_SNAPSHOT}"       >> "$BUILD_RECIPE_FILE"
 echo "${OLFS_SNAPSHOT_TAG}"  >> "$BUILD_RECIPE_FILE"
 echo "${HYRAX_SNAPSHOT_TAG}" >> "$BUILD_RECIPE_FILE"
-
 loggy "Updated $BUILD_RECIPE_FILE file:"
 loggy "$(cat "$BUILD_RECIPE_FILE")"
+
+cp "$BUILD_RECIPE_FILE" "$TRAVIS_BUILD_RECIPE_FILE"
+loggy "Updated $TRAVIS_BUILD_RECIPE_FILE file:"
+loggy "$(cat "$TRAVIS_BUILD_RECIPE_FILE")"
 
 
 # Bounding the commit message with the " character allows use to include


### PR DESCRIPTION
This enables the update of the `hyrax-docker/travis-build-recipe` file from the OLFS master branch which is where the el8 builds are happening. It will get merged (automagically) to the el9 branch once merged to master.